### PR TITLE
Extend Provider interface with lifecycle methods

### DIFF
--- a/providers/mysql/mysql.go
+++ b/providers/mysql/mysql.go
@@ -32,6 +32,22 @@ func (p *MySQLProvider) DefaultPorts() providers.PortRange {
 	}
 }
 
+func (p *MySQLProvider) FindBinary(version string) (string, error) {
+	return "", fmt.Errorf("MySQLProvider.FindBinary: use sandbox package directly (not yet migrated)")
+}
+
+func (p *MySQLProvider) CreateSandbox(config providers.SandboxConfig) (*providers.SandboxInfo, error) {
+	return nil, fmt.Errorf("MySQLProvider.CreateSandbox: use sandbox package directly (not yet migrated)")
+}
+
+func (p *MySQLProvider) StartSandbox(dir string) error {
+	return fmt.Errorf("MySQLProvider.StartSandbox: use sandbox package directly (not yet migrated)")
+}
+
+func (p *MySQLProvider) StopSandbox(dir string) error {
+	return fmt.Errorf("MySQLProvider.StopSandbox: use sandbox package directly (not yet migrated)")
+}
+
 func Register(reg *providers.Registry) error {
 	return reg.Register(NewMySQLProvider())
 }

--- a/providers/provider.go
+++ b/providers/provider.go
@@ -5,14 +5,39 @@ import (
 	"sort"
 )
 
+// SandboxConfig holds provider-agnostic sandbox configuration.
+type SandboxConfig struct {
+	Version    string
+	Dir        string            // sandbox directory path
+	Port       int               // primary port
+	AdminPort  int               // admin/management port (0 if not applicable)
+	Host       string            // bind address
+	DbUser     string            // admin username
+	DbPassword string            // admin password
+	Options    map[string]string // provider-specific key-value options
+}
+
+// SandboxInfo describes a deployed sandbox instance.
+type SandboxInfo struct {
+	Dir    string
+	Port   int
+	Socket string
+	Status string // "running", "stopped"
+}
+
 // Provider is the core abstraction for deploying database infrastructure.
-// Phase 2a defines a minimal interface (Name, ValidateVersion, DefaultPorts).
-// Phase 2b will add CreateSandbox, Start, Stop, Destroy, HealthCheck when
-// ProxySQL and other providers need them.
 type Provider interface {
 	Name() string
 	ValidateVersion(version string) error
 	DefaultPorts() PortRange
+	// FindBinary returns the path to the provider's main binary, or error if not found.
+	FindBinary(version string) (string, error)
+	// CreateSandbox deploys a new sandbox instance.
+	CreateSandbox(config SandboxConfig) (*SandboxInfo, error)
+	// StartSandbox starts a stopped sandbox.
+	StartSandbox(dir string) error
+	// StopSandbox stops a running sandbox.
+	StopSandbox(dir string) error
 }
 
 type PortRange struct {

--- a/providers/provider_test.go
+++ b/providers/provider_test.go
@@ -7,6 +7,10 @@ type mockProvider struct{ name string }
 func (m *mockProvider) Name() string                         { return m.name }
 func (m *mockProvider) ValidateVersion(version string) error { return nil }
 func (m *mockProvider) DefaultPorts() PortRange              { return PortRange{BasePort: 9999, PortsPerInstance: 1} }
+func (m *mockProvider) FindBinary(version string) (string, error) { return "/usr/bin/mock", nil }
+func (m *mockProvider) CreateSandbox(config SandboxConfig) (*SandboxInfo, error) { return &SandboxInfo{Dir: "/tmp/mock"}, nil }
+func (m *mockProvider) StartSandbox(dir string) error { return nil }
+func (m *mockProvider) StopSandbox(dir string) error  { return nil }
 
 func TestRegistryRegisterAndGet(t *testing.T) {
 	reg := NewRegistry()


### PR DESCRIPTION
## Summary
- Add `SandboxConfig` and `SandboxInfo` types to `providers/provider.go`
- Extend the `Provider` interface with `FindBinary`, `CreateSandbox`, `StartSandbox`, and `StopSandbox` methods
- Add stub implementations in `MySQLProvider` that return "not yet migrated" errors
- Update mock provider in tests to satisfy the extended interface

## Test plan
- [x] `go test ./providers/... -v` — all 7 tests pass
- [x] `go build -o dbdeployer .` — builds successfully

Closes #36

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Extended provider interface with methods for sandbox binary discovery, creation, and lifecycle management.
  * Introduced `SandboxConfig` and `SandboxInfo` types to standardize sandbox configuration and operational state across providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->