### PR TITLE
Handle ProxySQL cleanup during sandbox deletion

### DIFF
--- a/sandbox/sandbox.go
+++ b/sandbox/sandbox.go
@@ -1245,6 +1245,13 @@ func RemoveSandbox(sandboxDir, sandbox string, runConcurrently bool) (execList [
 		}
 	}
 
+	// If a proxysql sub-sandbox exists, stop it before removing the directory
+	proxysqlStop := path.Join(fullPath, "proxysql", "stop")
+	if _, statErr := os.Stat(proxysqlStop); statErr == nil {
+		common.CondPrintf("Stopping ProxySQL in %s\n", path.Join(fullPath, "proxysql"))
+		_, _ = common.RunCmd(proxysqlStop)
+	}
+
 	rmTargets := []string{fullPath, logDirectory}
 
 	for _, target := range rmTargets {
@@ -1357,6 +1364,13 @@ func RemoveCustomSandbox(sandboxDir, sandbox string, runConcurrently, useStop bo
 		if common.FileExists(defaultExecutable) {
 			_ = os.Remove(defaultExecutable)
 		}
+	}
+
+	// If a proxysql sub-sandbox exists, stop it before removing the directory
+	proxysqlStop := path.Join(fullPath, "proxysql", "stop")
+	if _, statErr := os.Stat(proxysqlStop); statErr == nil {
+		common.CondPrintf("Stopping ProxySQL in %s\n", path.Join(fullPath, "proxysql"))
+		_, _ = common.RunCmd(proxysqlStop)
 	}
 
 	rmTargets := []string{fullPath, logDirectory}


### PR DESCRIPTION
Closes #42

## Summary
- Before a sandbox directory is removed during `dbdeployer delete`, check if a `proxysql/` subdirectory exists with a `stop` script
- If found, run `proxysql/stop` to gracefully shut down the ProxySQL process before the directory is deleted
- Applied to both `RemoveSandbox` (deprecated) and `RemoveCustomSandbox` functions

## Test plan
- [ ] Build succeeds: `go build -o dbdeployer .`
- [ ] `dbdeployer delete` works normally for sandboxes without ProxySQL
- [ ] `dbdeployer delete` stops ProxySQL before cleanup for sandboxes with a `proxysql/` subdirectory