### PR TITLE
Fix group replication and multi-source for MySQL 8.4+

### DIFF
--- a/globals/globals.go
+++ b/globals/globals.go
@@ -419,6 +419,8 @@ var (
 	MinimumShowReplicaStatusVersion           = NumericVersion{8, 0, 22}
 	MinimumChangeReplicationSourceVersion     = NumericVersion{8, 0, 23}
 	MinimumShowBinaryLogStatusVersion         = NumericVersion{8, 2, 0}
+	MinimumNoWriteSetExtractionVersion        = NumericVersion{8, 3, 0}
+	MinimumResetBinaryLogsVersion             = NumericVersion{8, 4, 0}
 )
 
 const (

--- a/sandbox/group_replication.go
+++ b/sandbox/group_replication.go
@@ -244,6 +244,7 @@ func CreateGroupReplication(sandboxDef SandboxDef, origin string, nodes int, mas
 	data["MasterPasswordParam"] = replCmds["MasterPasswordParam"]
 	data["StartReplica"] = replCmds["StartReplica"]
 	data["StopReplica"] = replCmds["StopReplica"]
+	data["ResetMasterCmd"] = replCmds["ResetMasterCmd"]
 	connectionString := ""
 	for i := 0; i < nodes; i++ {
 		groupPort := baseGroupPort + i + 1
@@ -305,6 +306,7 @@ func CreateGroupReplication(sandboxDef SandboxDef, origin string, nodes int, mas
 			"ChangeMasterTo":       replCmds["ChangeMasterTo"],
 			"MasterUserParam":      replCmds["MasterUserParam"],
 			"MasterPasswordParam":  replCmds["MasterPasswordParam"],
+			"ResetMasterCmd":       replCmds["ResetMasterCmd"],
 			"MasterLabel":          masterLabel,
 			"MasterAbbr":           masterAbbr,
 			"SandboxDir":           sandboxDef.SandboxDir,
@@ -332,11 +334,18 @@ func CreateGroupReplication(sandboxDef SandboxDef, origin string, nodes int, mas
 		}
 
 		basePortText := fmt.Sprintf("%08d", basePort)
+
+		// Version-aware options for group replication
+		useReplicaUpdates, _ := common.GreaterOrEqualVersion(sandboxDef.Version, globals.MinimumShowReplicaStatusVersion)
+		useNoWriteSetExtraction, _ := common.GreaterOrEqualVersion(sandboxDef.Version, globals.MinimumNoWriteSetExtractionVersion)
+
 		replicationData := common.StringMap{
-			"BasePort":       basePortText,
-			"GroupSeeds":     connectionString,
-			"LocalAddresses": fmt.Sprintf("%s:%d", masterIp, groupPort),
-			"PrimaryMode":    singlePrimaryMode,
+			"BasePort":                  basePortText,
+			"GroupSeeds":                connectionString,
+			"LocalAddresses":            fmt.Sprintf("%s:%d", masterIp, groupPort),
+			"PrimaryMode":               singlePrimaryMode,
+			"UseReplicaUpdates":         useReplicaUpdates,
+			"SkipWriteSetExtraction":    useNoWriteSetExtraction,
 		}
 
 		replOptionsText, err := common.SafeTemplateFill("group_replication",
@@ -350,7 +359,11 @@ func CreateGroupReplication(sandboxDef SandboxDef, origin string, nodes int, mas
 		sandboxDef.ReplOptions = reMasterIp.ReplaceAllString(sandboxDef.ReplOptions, masterIp)
 
 		sandboxDef.ReplOptions += fmt.Sprintf("\n%s\n", SingleTemplates[globals.TmplGtidOptions57].Contents)
-		sandboxDef.ReplOptions += fmt.Sprintf("\n%s\n", SingleTemplates[globals.TmplReplCrashSafeOptions].Contents)
+		// master-info-repository and relay-log-info-repository removed in 8.4+
+		skipCrashSafeOpts, _ := common.GreaterOrEqualVersion(sandboxDef.Version, globals.MinimumResetBinaryLogsVersion)
+		if !skipCrashSafeOpts {
+			sandboxDef.ReplOptions += fmt.Sprintf("\n%s\n", SingleTemplates[globals.TmplReplCrashSafeOptions].Contents)
+		}
 
 		// 8.0.11
 		isMinimumMySQLXDefault, err := common.HasCapability(sandboxDef.Flavor, common.MySQLXDefault, sandboxDef.Version)
@@ -397,6 +410,7 @@ func CreateGroupReplication(sandboxDef SandboxDef, origin string, nodes int, mas
 			"ChangeMasterTo":       replCmds["ChangeMasterTo"],
 			"MasterUserParam":      replCmds["MasterUserParam"],
 			"MasterPasswordParam":  replCmds["MasterPasswordParam"],
+			"ResetMasterCmd":       replCmds["ResetMasterCmd"],
 			"SlaveLabel":           slaveLabel,
 			"SlaveAbbr":            slaveAbbr,
 			"SandboxDir":           sandboxDef.SandboxDir,

--- a/sandbox/multi-source-replication.go
+++ b/sandbox/multi-source-replication.go
@@ -113,7 +113,10 @@ func CreateAllMastersReplication(sandboxDef SandboxDef, origin string, nodes int
 	}
 
 	sandboxDef.GtidOptions = SingleTemplates[globals.TmplGtidOptions57].Contents
-	sandboxDef.ReplCrashSafeOptions = SingleTemplates[globals.TmplReplCrashSafeOptions].Contents
+	skipCrashSafeOpts, _ := common.GreaterOrEqualVersion(sandboxDef.Version, globals.MinimumResetBinaryLogsVersion)
+	if !skipCrashSafeOpts {
+		sandboxDef.ReplCrashSafeOptions = SingleTemplates[globals.TmplReplCrashSafeOptions].Contents
+	}
 	if sandboxDef.DirName == "" {
 		sandboxDef.DirName += defaults.Defaults().AllMastersPrefix + common.VersionToName(origin)
 	}
@@ -183,17 +186,9 @@ func CreateAllMastersReplication(sandboxDef SandboxDef, origin string, nodes int
 	data["NodeLabel"] = defaults.Defaults().NodePrefix
 	data["ChangeMasterExtra"] = setChangeMasterProperties("", sandboxDef.ChangeMasterOptions, logger)
 	replCmds := replicationCommands(sandboxDef.Version)
-	data["ShowMasterStatus"] = replCmds["ShowMasterStatus"]
-	data["ShowSlaveStatus"] = replCmds["ShowSlaveStatus"]
-	data["ChangeMasterTo"] = replCmds["ChangeMasterTo"]
-	data["StartReplica"] = replCmds["StartReplica"]
-	data["StopReplica"] = replCmds["StopReplica"]
-	data["ResetReplica"] = replCmds["ResetReplica"]
-	data["MasterPosWaitFunc"] = replCmds["MasterPosWaitFunc"]
-	data["MasterHostParam"] = replCmds["MasterHostParam"]
-	data["MasterPortParam"] = replCmds["MasterPortParam"]
-	data["MasterUserParam"] = replCmds["MasterUserParam"]
-	data["MasterPasswordParam"] = replCmds["MasterPasswordParam"]
+	for k, v := range replCmds {
+		data[k] = v
+	}
 	logger.Printf("Writing master and slave scripts in %s\n", sandboxDef.SandboxDir)
 	for _, node := range slaveList {
 		data["Node"] = node
@@ -330,7 +325,10 @@ func CreateFanInReplication(sandboxDef SandboxDef, origin string, nodes int, mas
 		slaveList = globals.SlaveListValue
 	}
 	sandboxDef.GtidOptions = SingleTemplates[globals.TmplGtidOptions57].Contents
-	sandboxDef.ReplCrashSafeOptions = SingleTemplates[globals.TmplReplCrashSafeOptions].Contents
+	skipCrashSafe2, _ := common.GreaterOrEqualVersion(sandboxDef.Version, globals.MinimumResetBinaryLogsVersion)
+	if !skipCrashSafe2 {
+		sandboxDef.ReplCrashSafeOptions = SingleTemplates[globals.TmplReplCrashSafeOptions].Contents
+	}
 	if sandboxDef.DirName == "" {
 		sandboxDef.DirName = defaults.Defaults().FanInPrefix + common.VersionToName(origin)
 	}
@@ -420,17 +418,9 @@ func CreateFanInReplication(sandboxDef SandboxDef, origin string, nodes int, mas
 	data["ChangeMasterExtra"] = setChangeMasterProperties("", sandboxDef.ChangeMasterOptions, logger)
 	data["MasterIp"] = masterIp
 	replCmds := replicationCommands(sandboxDef.Version)
-	data["ShowMasterStatus"] = replCmds["ShowMasterStatus"]
-	data["ShowSlaveStatus"] = replCmds["ShowSlaveStatus"]
-	data["ChangeMasterTo"] = replCmds["ChangeMasterTo"]
-	data["StartReplica"] = replCmds["StartReplica"]
-	data["StopReplica"] = replCmds["StopReplica"]
-	data["ResetReplica"] = replCmds["ResetReplica"]
-	data["MasterPosWaitFunc"] = replCmds["MasterPosWaitFunc"]
-	data["MasterHostParam"] = replCmds["MasterHostParam"]
-	data["MasterPortParam"] = replCmds["MasterPortParam"]
-	data["MasterUserParam"] = replCmds["MasterUserParam"]
-	data["MasterPasswordParam"] = replCmds["MasterPasswordParam"]
+	for k, v := range replCmds {
+		data[k] = v
+	}
 	logger.Printf("Writing master and slave scripts in %s\n", sandboxDef.SandboxDir)
 	for _, slave := range slist {
 		data["Node"] = slave

--- a/sandbox/pxc_replication.go
+++ b/sandbox/pxc_replication.go
@@ -225,7 +225,12 @@ func CreatePxcReplication(sandboxDef SandboxDef, origin string, nodes int, maste
 		return err
 	}
 	if !skipLogSlaveUpdates {
-		sandboxDef.ReplOptions = fmt.Sprintf("%s\nlog_slave_updates=ON\n", sandboxDef.ReplOptions)
+		useReplicaUpdates, _ := common.GreaterOrEqualVersion(sandboxDef.Version, globals.MinimumShowReplicaStatusVersion)
+		if useReplicaUpdates {
+			sandboxDef.ReplOptions = fmt.Sprintf("%s\nlog_replica_updates=ON\n", sandboxDef.ReplOptions)
+		} else {
+			sandboxDef.ReplOptions = fmt.Sprintf("%s\nlog_slave_updates=ON\n", sandboxDef.ReplOptions)
+		}
 	}
 	baseReplicationOptions := sandboxDef.ReplOptions
 	var groupCommunication string = "gcomm://"
@@ -322,7 +327,11 @@ func CreatePxcReplication(sandboxDef SandboxDef, origin string, nodes int, maste
 		sandboxDef.ReplOptions = baseReplicationOptions + fmt.Sprintf("\n%s\n", pxcFilledTemplate)
 
 		sandboxDef.ReplOptions += fmt.Sprintf("\n%s\n", SingleTemplates[globals.TmplGtidOptions57].Contents)
-		sandboxDef.ReplOptions += fmt.Sprintf("\n%s\n", SingleTemplates[globals.TmplReplCrashSafeOptions].Contents)
+		// master-info-repository and relay-log-info-repository removed in 8.4+
+		skipCrashSafeOpts, _ := common.GreaterOrEqualVersion(sandboxDef.Version, globals.MinimumResetBinaryLogsVersion)
+		if !skipCrashSafeOpts {
+			sandboxDef.ReplOptions += fmt.Sprintf("\n%s\n", SingleTemplates[globals.TmplReplCrashSafeOptions].Contents)
+		}
 		// 8.0.11
 		isMinimumMySQLXDefault, err := common.HasCapability(sandboxDef.Flavor, common.MySQLXDefault, sandboxDef.Version)
 		if err != nil {

--- a/sandbox/replication.go
+++ b/sandbox/replication.go
@@ -37,6 +37,7 @@ func replicationCommands(version string) map[string]string {
 		"StartReplica":        "START SLAVE",
 		"StopReplica":         "STOP SLAVE",
 		"ResetReplica":        "RESET SLAVE",
+		"ResetMasterCmd":      "reset master",
 		"MasterPosWaitFunc":   "master_pos_wait",
 		"MasterHostParam":     "master_host",
 		"MasterPortParam":     "master_port",
@@ -65,6 +66,11 @@ func replicationCommands(version string) map[string]string {
 	useBinaryLogStatus, _ := common.GreaterOrEqualVersion(version, globals.MinimumShowBinaryLogStatusVersion)
 	if useBinaryLogStatus {
 		cmds["ShowMasterStatus"] = "show binary log status"
+	}
+
+	useResetBinaryLogs, _ := common.GreaterOrEqualVersion(version, globals.MinimumResetBinaryLogsVersion)
+	if useResetBinaryLogs {
+		cmds["ResetMasterCmd"] = "RESET BINARY LOGS AND GTIDS"
 	}
 
 	return cmds
@@ -269,6 +275,7 @@ func CreateMasterSlaveReplication(sandboxDef SandboxDef, origin string, nodes in
 		"StartReplica":        replCmds["StartReplica"],
 		"StopReplica":         replCmds["StopReplica"],
 		"ResetReplica":        replCmds["ResetReplica"],
+		"ResetMasterCmd":      replCmds["ResetMasterCmd"],
 		"MasterPosWaitFunc":   replCmds["MasterPosWaitFunc"],
 		"MasterHostParam":     replCmds["MasterHostParam"],
 		"MasterPortParam":     replCmds["MasterPortParam"],
@@ -376,6 +383,7 @@ func CreateMasterSlaveReplication(sandboxDef SandboxDef, origin string, nodes in
 			"MasterUserParam":     replCmds["MasterUserParam"],
 			"MasterPasswordParam": replCmds["MasterPasswordParam"],
 			"MasterPosWaitFunc":   replCmds["MasterPosWaitFunc"],
+			"ResetMasterCmd":      replCmds["ResetMasterCmd"],
 		})
 		sandboxDef.LoadGrants = false
 		sandboxDef.Prompt = fmt.Sprintf("%s%d", slaveLabel, i)
@@ -446,6 +454,7 @@ func CreateMasterSlaveReplication(sandboxDef SandboxDef, origin string, nodes in
 			"MasterUserParam":     replCmds["MasterUserParam"],
 			"MasterPasswordParam": replCmds["MasterPasswordParam"],
 			"MasterPosWaitFunc":   replCmds["MasterPosWaitFunc"],
+			"ResetMasterCmd":      replCmds["ResetMasterCmd"],
 		}
 		logger.Printf("Defining replication node data: %v\n", stringMapToJson(dataSlave))
 		logger.Printf("Create slave script %d\n", i)

--- a/sandbox/templates/group/group_repl_options.gotxt
+++ b/sandbox/templates/group/group_repl_options.gotxt
@@ -1,12 +1,12 @@
 
 # After customization, these options are added to my.sandbox.cnf
 binlog_checksum=NONE
-log_slave_updates=ON
+{{if .UseReplicaUpdates}}log_replica_updates=ON{{else}}log_slave_updates=ON{{end}}
 plugin-load-add=group_replication.so
 group_replication=FORCE_PLUS_PERMANENT
 group_replication_start_on_boot=OFF
 group_replication_bootstrap_group=OFF
-transaction_write_set_extraction=XXHASH64
+{{if not .SkipWriteSetExtraction}}transaction_write_set_extraction=XXHASH64{{end}}
 report-host=127.0.0.1
 loose-group_replication_group_name="{{.BasePort}}-bbbb-cccc-dddd-eeeeeeeeeeee"
 loose-group-replication-local-address={{.LocalAddresses}}

--- a/sandbox/templates/group/init_nodes.gotxt
+++ b/sandbox/templates/group/init_nodes.gotxt
@@ -8,7 +8,7 @@ multi_sb={{.SandboxDir}}
 {{end}}
 [ -z "$SLEEP_TIME" ] && SLEEP_TIME=1
 {{range .Nodes}}
-    user_cmd='reset master;'
+    user_cmd='{{.ResetMasterCmd}};'
     user_cmd="$user_cmd {{.ChangeMasterTo}} {{.MasterUserParam}}='rsandbox', {{.MasterPasswordParam}}='rsandbox' {{.ChangeMasterExtra}} FOR CHANNEL 'group_replication_recovery';"
 	echo "# Node {{.Node}} # $user_cmd"
     $multi_sb/{{.NodeLabel}}{{.Node}}/use -u root -e "$user_cmd"

--- a/sandbox/templates/replication/multi_source.gotxt
+++ b/sandbox/templates/replication/multi_source.gotxt
@@ -4,7 +4,7 @@
 SBDIR={{.SandboxDir}}
 cd "$SBDIR"
 
-$SBDIR/use_all 'reset master'
+$SBDIR/use_all '{{.ResetMasterCmd}}'
 
 MASTERS="{{.MasterList}}"
 SLAVES="{{.SlaveList}}"

--- a/sandbox/templates/single/clear.gotxt
+++ b/sandbox/templates/single/clear.gotxt
@@ -43,7 +43,12 @@ fi
 is_master=$(ls data | grep 'mysql-bin')
 if [ -n "$is_master" ]
 then
-    ./use -e 'reset master'
+    minimum_version_reset_binary_logs="008004000"
+    if [[ "v$sortable_version" > "v$minimum_version_reset_binary_logs" ]] || [[ "v$sortable_version" == "v$minimum_version_reset_binary_logs" ]]; then
+        ./use -e 'RESET BINARY LOGS AND GTIDS'
+    else
+        ./use -e 'reset master'
+    fi
 fi
 
 ./stop


### PR DESCRIPTION
## Summary
Fixes group replication deployment on MySQL 8.4+ and 9.x.

### Critical (caused startup failure)
- `transaction_write_set_extraction=XXHASH64` removed in 8.3+ — now version-conditional
- `master-info-repository=table` / `relay-log-info-repository=table` removed in 8.4+ — skipped for 8.4+
- `RESET MASTER` removed in 8.4+ — replaced with `RESET BINARY LOGS AND GTIDS`

### Deprecated (warnings)
- `log_slave_updates` → `log_replica_updates` for 8.0.22+

### Files changed
- `globals/globals.go` — new version constants
- `sandbox/replication.go` — `ResetMasterCmd` in replication commands
- `sandbox/group_replication.go` — version-aware options + crash-safe skip
- `sandbox/pxc_replication.go` — version-aware log_replica_updates + crash-safe skip
- `sandbox/multi-source-replication.go` — simplified replCmds loop + crash-safe skip
- 4 template files updated

### Tested
- Group replication 8.4.4: 3 nodes ONLINE ✅
- Group replication 9.1.0: 3 nodes ONLINE ✅
- Unit tests: all pass ✅

Closes #49