### PR TITLE
ci: add install script test workflow

### DIFF
--- a/.github/workflows/install_script_test.yml
+++ b/.github/workflows/install_script_test.yml
@@ -1,0 +1,57 @@
+name: Install Script Test
+
+# Tests the documented installation flow:
+#   curl -s https://raw.githubusercontent.com/ProxySQL/dbdeployer/master/scripts/dbdeployer-install.sh | bash
+#
+# This catches release-asset mismatches (wrong file naming, missing
+# checksums.txt, missing tarballs) that would break the install script
+# for end users. Runs automatically after a release is published, on a
+# weekly schedule, and on manual dispatch.
+#
+# Security note: this workflow uses no user-controlled inputs (issue
+# bodies, PR titles, commit messages, etc.). The matrix values are
+# hardcoded here and matrix.os is safe to interpolate.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+  schedule:
+    - cron: '0 4 * * 1'
+
+jobs:
+  install-script:
+    name: Install on ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, ubuntu-24.04, macos-13, macos-14]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Prepare a PATH directory the install script will accept
+        run: |
+          mkdir -p "$HOME/bin"
+          echo "$HOME/bin" >> "$GITHUB_PATH"
+
+      - name: Run the documented install command
+        run: |
+          curl -s https://raw.githubusercontent.com/ProxySQL/dbdeployer/master/scripts/dbdeployer-install.sh | bash
+
+      - name: Verify dbdeployer runs and version matches common/VERSION
+        run: |
+          which dbdeployer
+          dbdeployer --version
+          INSTALLED_VERSION=$(dbdeployer --version | awk '{print $NF}')
+          EXPECTED_VERSION=$(curl -s https://raw.githubusercontent.com/ProxySQL/dbdeployer/master/common/VERSION)
+          echo "Installed: $INSTALLED_VERSION"
+          echo "Expected:  $EXPECTED_VERSION"
+          [ "$INSTALLED_VERSION" = "$EXPECTED_VERSION" ] || {
+            echo "FAIL: installed version does not match common/VERSION"
+            exit 1
+          }
+
+      - name: Smoke test basic commands
+        run: |
+          dbdeployer --help > /dev/null
+          dbdeployer versions > /dev/null || true
+          dbdeployer defaults show > /dev/null


### PR DESCRIPTION
## Summary

Adds a new GitHub Actions workflow that tests the documented install flow end-to-end:

\`\`\`
curl -s https://raw.githubusercontent.com/ProxySQL/dbdeployer/master/scripts/dbdeployer-install.sh | bash
\`\`\`

## Motivation

v2.2.1 was initially released with binaries named \`dbdeployer-2.2.1-linux-amd64\` (plain binaries, wrong naming, no \`checksums.txt\`), but the install script expects tar.gz archives named \`dbdeployer-2.2.1.linux_amd64.tar.gz\` + a \`checksums.txt\`. This broke \`curl | bash\` for end users and wasn't caught because nothing tested the install flow.

## What it tests

- Downloads the install script via the documented URL
- Runs it on Ubuntu 22.04/24.04 and macOS 13/14
- Verifies \`dbdeployer --version\` works and matches \`common/VERSION\` on master
- Smoke tests basic commands (\`--help\`, \`versions\`, \`defaults show\`)

## Triggers

- \`release: published\` — catches asset mismatches right after a release is cut
- \`schedule: weekly\` — catches upstream URL/redirect regressions
- \`workflow_dispatch\` — for manual sanity checks

## Test plan
- [ ] PR CI passes syntax validation
- [ ] Manually dispatch on this branch after merge to verify end-to-end against the v2.2.1 release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated validation of the installation process across multiple operating systems (Ubuntu and macOS) to ensure the install script functions correctly and installed versions match expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->