### PR TITLE
ci: add MySQL 5.6 to sandbox-test matrix

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -48,7 +48,7 @@ jobs:
           path: /tmp/mysql-tarball
           key: mysql-${{ matrix.mysql-version }}-linux-x86_64-v1
 
-      - name: Download MySQL
+      - name: Resolve tarball name
         run: |
           SHORT_VER=$(echo "$MYSQL_VERSION" | grep -oP '^\d+\.\d+')
           # MySQL 5.6 ships as .tar.gz built against glibc2.12; 5.7+ ships
@@ -58,6 +58,11 @@ jobs:
           else
             TARBALL="mysql-${MYSQL_VERSION}-linux-glibc2.17-x86_64.tar.xz"
           fi
+          echo "SHORT_VER=$SHORT_VER" >> "$GITHUB_ENV"
+          echo "TARBALL=$TARBALL" >> "$GITHUB_ENV"
+
+      - name: Download MySQL
+        run: |
           mkdir -p /tmp/mysql-tarball
           if [ ! -f "/tmp/mysql-tarball/$TARBALL" ]; then
             echo "Downloading $TARBALL..."
@@ -71,12 +76,6 @@ jobs:
       - name: Unpack MySQL
         run: |
           mkdir -p "$SANDBOX_BINARY"
-          SHORT_VER=$(echo "$MYSQL_VERSION" | grep -oP '^\d+\.\d+')
-          if [ "$SHORT_VER" = "5.6" ]; then
-            TARBALL="mysql-${MYSQL_VERSION}-linux-glibc2.12-x86_64.tar.gz"
-          else
-            TARBALL="mysql-${MYSQL_VERSION}-linux-glibc2.17-x86_64.tar.xz"
-          fi
           ./dbdeployer unpack "/tmp/mysql-tarball/$TARBALL" \
             --sandbox-binary="$SANDBOX_BINARY"
 

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -18,6 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         mysql-version:
+          - '5.6.51'
           - '8.0.42'
           - '8.4.4'
           - '9.1.0'
@@ -50,7 +51,13 @@ jobs:
       - name: Download MySQL
         run: |
           SHORT_VER=$(echo "$MYSQL_VERSION" | grep -oP '^\d+\.\d+')
-          TARBALL="mysql-${MYSQL_VERSION}-linux-glibc2.17-x86_64.tar.xz"
+          # MySQL 5.6 ships as .tar.gz built against glibc2.12; 5.7+ ships
+          # as .tar.xz built against glibc2.17.
+          if [ "$SHORT_VER" = "5.6" ]; then
+            TARBALL="mysql-${MYSQL_VERSION}-linux-glibc2.12-x86_64.tar.gz"
+          else
+            TARBALL="mysql-${MYSQL_VERSION}-linux-glibc2.17-x86_64.tar.xz"
+          fi
           mkdir -p /tmp/mysql-tarball
           if [ ! -f "/tmp/mysql-tarball/$TARBALL" ]; then
             echo "Downloading $TARBALL..."
@@ -64,7 +71,12 @@ jobs:
       - name: Unpack MySQL
         run: |
           mkdir -p "$SANDBOX_BINARY"
-          TARBALL="mysql-${MYSQL_VERSION}-linux-glibc2.17-x86_64.tar.xz"
+          SHORT_VER=$(echo "$MYSQL_VERSION" | grep -oP '^\d+\.\d+')
+          if [ "$SHORT_VER" = "5.6" ]; then
+            TARBALL="mysql-${MYSQL_VERSION}-linux-glibc2.12-x86_64.tar.gz"
+          else
+            TARBALL="mysql-${MYSQL_VERSION}-linux-glibc2.17-x86_64.tar.xz"
+          fi
           ./dbdeployer unpack "/tmp/mysql-tarball/$TARBALL" \
             --sandbox-binary="$SANDBOX_BINARY"
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ dbdeployer deploy single 8.0.40
 
 | Provider | Single | Replication | Group Replication | ProxySQL Wiring |
 |----------|:------:|:-----------:|:-----------------:|:---------------:|
-| **MySQL** (8.0, 8.4, 9.x) | ✓ | ✓ | ✓ | ✓ |
+| **MySQL** (5.6, 5.7, 8.0, 8.4, 9.x) | ✓ | ✓ | ✓ (5.7.17+) | ✓ |
 | **PostgreSQL** (12+) | ✓ | ✓ (streaming) | — | ✓ |
 | **ProxySQL** | ✓ | — | — | — |
 | Percona Server | ✓ | ✓ | ✓ | ✓ |

--- a/website/src/content/docs/providers/mysql.md
+++ b/website/src/content/docs/providers/mysql.md
@@ -9,7 +9,7 @@ The MySQL provider is the core of dbdeployer. It supports MySQL Community Server
 
 | Flavor | Tarball prefix | Notes |
 |--------|---------------|-------|
-| MySQL Community Server | `mysql-` | Default; versions 5.7, 8.0, 8.4, 9.x |
+| MySQL Community Server | `mysql-` | Default; versions 5.6, 5.7, 8.0, 8.4, 9.x |
 | Percona Server | `Percona-Server-` | Drop-in MySQL replacement with extra features |
 | MariaDB | `mariadb-` | Compatible with MySQL 5.7 API; some features differ |
 
@@ -85,6 +85,7 @@ dbdeployer deploy single lab_8.0.35
 
 | Series | Status | Topologies |
 |--------|--------|-----------|
+| 5.6.x | Legacy | single, replication (GTID 5.6.9+), fan-in/all-masters unsupported |
 | 5.7.x | Legacy | single, replication, group (5.7.17+) |
 | 8.0.x | Stable | all topologies |
 | 8.4.x | LTS (recommended) | all topologies |
@@ -96,8 +97,8 @@ All topologies are deployed with `dbdeployer deploy replication <version> --topo
 
 | Topology | Flag | Min Version |
 |----------|------|-------------|
-| Single | `deploy single` | any |
-| Master-slave | `--topology=master-slave` (default) | any |
+| Single | `deploy single` | 5.6 |
+| Master-slave | `--topology=master-slave` (default) | 5.6 |
 | Group Replication | `--topology=group` | 5.7.17 |
 | Single-primary GR | `--topology=group --single-primary` | 5.7.17 |
 | InnoDB Cluster | `--topology=innodb-cluster` | 8.0 |

--- a/website/src/content/docs/providers/mysql.md
+++ b/website/src/content/docs/providers/mysql.md
@@ -85,7 +85,7 @@ dbdeployer deploy single lab_8.0.35
 
 | Series | Status | Topologies |
 |--------|--------|-----------|
-| 5.6.x | Legacy | single, replication (GTID 5.6.9+), fan-in/all-masters unsupported |
+| 5.6.x | Legacy | single, replication |
 | 5.7.x | Legacy | single, replication, group (5.7.17+) |
 | 8.0.x | Stable | all topologies |
 | 8.4.x | LTS (recommended) | all topologies |
@@ -97,8 +97,8 @@ All topologies are deployed with `dbdeployer deploy replication <version> --topo
 
 | Topology | Flag | Min Version |
 |----------|------|-------------|
-| Single | `deploy single` | 5.6 |
-| Master-slave | `--topology=master-slave` (default) | 5.6 |
+| Single | `deploy single` | any |
+| Master-slave | `--topology=master-slave` (default) | any |
 | Group Replication | `--topology=group` | 5.7.17 |
 | Single-primary GR | `--topology=group --single-primary` | 5.7.17 |
 | InnoDB Cluster | `--topology=innodb-cluster` | 8.0 |


### PR DESCRIPTION
## Summary
- Add MySQL 5.6.51 to the `sandbox-test` matrix in `integration_tests.yml` (single + master-slave replication).
- Branch the download/unpack steps on short version: 5.6 uses `linux-glibc2.12-x86_64.tar.gz`, 5.7+ keeps `linux-glibc2.17-x86_64.tar.xz`.
- Update the README supported-databases row and the website MySQL provider docs so the matrix actually lists 5.6.

Context: dbdeployer has supported MySQL 5.6 since forever (capability gates like `MinimumCrashSafeVersion = 5.6.2`, `MinimumGtidVersion = 5.6.9` in `globals/globals.go`), but CI never exercised it and the docs implied 5.7 was the floor.

## Test plan
- [ ] `Sandbox (5.6.51)` job succeeds: unpack, deploy single, deploy replication, `check_slaves`, `test_replication`.
- [ ] Other matrix entries (8.0, 8.4, 9.x) still pass.
- [ ] No impact on unrelated jobs (Percona, MariaDB, InnoDB Cluster, etc.).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Extended MySQL version support to include versions 5.6 and 5.7 (in addition to 8.0, 8.4, 9.x).
  * Updated Group Replication compatibility requirements (5.7.17+ minimum).
  * Added topology constraint documentation for legacy MySQL versions.

* **Tests**
  * Enhanced integration tests to cover MySQL 5.6 compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->