### PR TITLE
Fix update cmd

### DIFF
--- a/cmd/update.go
+++ b/cmd/update.go
@@ -56,11 +56,7 @@ func updateDbDeployer(cmd *cobra.Command, args []string) {
 	if currentOS == "macos" || currentOS == "darwin" {
 		currentOS = "osx"
 	}
-	arch := ""
-	if OS == "linux" {
-		// check the architecture
-		arch = runtime.GOARCH
-	}
+	arch := runtime.GOARCH
 	if dryRun {
 		verbose = true
 	}

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -108,7 +108,7 @@ func updateDbDeployer(cmd *cobra.Command, args []string) {
 	}
 
 	fileNameLong := ""
-	if OS == "linux" {
+	if OS == "linux" || OS == "osx" {
 		fileNameLong = fmt.Sprintf("dbdeployer-%s%s.%s_%s", tag, docsLabel, OS, arch)
 	} else {
 		fileNameLong = fmt.Sprintf("dbdeployer-%s%s.%s", tag, docsLabel, OS)

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -56,6 +56,11 @@ func updateDbDeployer(cmd *cobra.Command, args []string) {
 	if currentOS == "macos" || currentOS == "darwin" {
 		currentOS = "osx"
 	}
+	arch := ""
+	if OS == "linux" {
+		// check the architecture
+		arch = runtime.GOARCH
+	}
 	if dryRun {
 		verbose = true
 	}
@@ -106,9 +111,15 @@ func updateDbDeployer(cmd *cobra.Command, args []string) {
 		docsLabel = "-docs"
 	}
 
-	fileName := fmt.Sprintf("dbdeployer-%s%s.%s", tag, docsLabel, OS)
-	tarballName := fileName + ".tar.gz"
+	fileNameLong := ""
+	if OS == "linux" {
+		fileNameLong = fmt.Sprintf("dbdeployer-%s%s.%s_%s", tag, docsLabel, OS, arch)
+	} else {
+		fileNameLong = fmt.Sprintf("dbdeployer-%s%s.%s", tag, docsLabel, OS)
+	}
+	tarballName := fileNameLong + ".tar.gz"
 	signatureName := tarballName + ".sha256"
+	fileName := "dbdeployer"
 
 	fileUrl := ""
 	signatureUrl := ""
@@ -243,7 +254,7 @@ var updateCmd = &cobra.Command{
 	Long:  `Updates dbdeployer in place using the latest version (or one of your choice)`,
 	Example: `
 $ dbdeployer update
-# gets the latest release, overwrites current dbdeployer binaries 
+# gets the latest release, overwrites current dbdeployer binaries
 
 $ dbdeployer update --dry-run
 # shows what it will do, but does not do it

--- a/rest/rest.go
+++ b/rest/rest.go
@@ -221,7 +221,7 @@ func getReleaseText(tag string) ([]byte, error) {
 	if tag != "" && tag != "latest" {
 		tag = "tags/" + tag
 	}
-	releaseUrl := fmt.Sprintf("https://api.github.com/repos/datacharmer/dbdeployer/releases%s%s", endUrl, tag)
+	releaseUrl := fmt.Sprintf("https://api.github.com/repos/ProxySQL/dbdeployer/releases%s%s", endUrl, tag)
 	if os.Getenv("SBDEBUG") != "" {
 		fmt.Printf("%s\n", releaseUrl)
 	}


### PR DESCRIPTION
Fix issue #93 using the new repo and the new architecture binaries (AMD64 and ARM64)

I didn't test on other operating system.

```
$ go run . update --verbose
https://api.github.com/repos/ProxySQL/dbdeployer/releases/latest
Remote version:      2.2.3
Remote file:         dbdeployer-2.2.3.linux_amd64.tar.gz
OS:                  linux
dbdeployer location: /home/fred/bin

--------------------------------------------------------------------------------
Release : v2.2.3
Date    : 2026-04-24T05:19:04Z
## Changelog
* 25587042108de660cf9e60ba53cb8e1292278a32 Merge pull request #90 from ProxySQL/ci/mysql-5-6
* f926aa79dd85fb8e89e97ea3cd243b5f05b6c1ce Merge pull request #92 from ProxySQL/security/symlink-chain-traversal
* 7cc2cc7f951d71cf9f87fdd7dc0251cce6c60c51 ci: add MySQL 5.6 to sandbox-test matrix
* 2e3683493b1ddfbaa2a3c7b63ab13123f2e4e128 ci: bump VillageSQL deploy job to ubuntu-24.04
* 373c9c07afd95c9bf225eac352852b889e135187 ci: hardcode VillageSQL version in job name
* 21ca66fcc05e8def6e5a69a57d466da067587c6c fix: reject incompatible mysqlsh before InnoDB Cluster deploy
* d12ccf249368ba72e0d803b351b8679387b74401 release: prepare v2.2.3
* 40df0247c6347be9301e440f6ef289d10e6df8a6 review: address PR feedback from CodeRabbit and Gemini
* 8df4c643f4d45b878488a869781d64e52cd5af5a review: address PR feedback from CodeRabbit and Gemini
* e056a318d6a08d43435fbfd2dee871c7e39ed747 security: reject chain-symlink path traversal in tar extraction


--------------------------------------------------------------------------------
	checksums.txt (404 B)
	dbdeployer-2.2.3.linux_amd64.tar.gz (4.5 MB) [CHOSEN]
	dbdeployer-2.2.3.linux_arm64.tar.gz (4.2 MB)
	dbdeployer-2.2.3.osx_amd64.tar.gz (4.6 MB)
	dbdeployer-2.2.3.osx_arm64.tar.gz (4.4 MB)
....  4.5 MB
4
File dbdeployer extracted from dbdeployer-2.2.3.linux_amd64.tar.gz
*** WARNING *** No SHA256 checksum found for dbdeployer-2.2.3.linux_amd64.tar.gz
File dbdeployer-2.2.3.linux_amd64.tar.gz removed
File dbdeployer moved to /home/fred/bin
dbdeployer version 2.2.2
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Linux updates now detect CPU architecture and fetch matching release assets automatically.

* **Chores**
  * Updated the upstream release source used to retrieve latest release information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->