### PR TITLE
Use the MariaDB Foundation REST API to download MariaDB Server

### DIFF
--- a/downloads/mariadb_api.go
+++ b/downloads/mariadb_api.go
@@ -205,7 +205,7 @@ func findBestMariaDBFile(files []mariaDBAPIFile, OS, arch string, minimal bool) 
 		matches = append(matches, fileInfo)
 	}
 
-	if len(matches) == 0 && requestedOS == "darwin" {
+	if len(matches) == 0 && strings.EqualFold(requestedOS, "darwin") {
 		for _, fileInfo := range files {
 			if isMariaDBTarball(fileInfo.FileName) && strings.EqualFold(valueOrEmpty(fileInfo.OS), "Source") {
 				matches = append(matches, fileInfo)

--- a/downloads/mariadb_api.go
+++ b/downloads/mariadb_api.go
@@ -238,10 +238,14 @@ func getTarballDescriptionFromMariaDBFile(apiFile mariaDBAPIFile) (TarballDescri
 	if err != nil {
 		flavor = "mariadb"
 	}
+	checksum := getPreferredMariaDBChecksum(apiFile.Checksum)
+	if checksum == "" {
+		return TarballDescription{}, fmt.Errorf("missing checksum in MariaDB API response for %s", apiFile.FileName)
+	}
 
 	return TarballDescription{
 		Name:            apiFile.FileName,
-		Checksum:        getPreferredMariaDBChecksum(apiFile.Checksum),
+		Checksum:        checksum,
 		OperatingSystem: normalizeDBDeployerOS(valueOrEmpty(apiFile.OS)),
 		Arch:            normalizeMariaDBArch(valueOrEmpty(apiFile.CPU)),
 		Url:             normalizeMariaDBDownloadURL(apiFile.FileDownloadURL),

--- a/downloads/mariadb_api.go
+++ b/downloads/mariadb_api.go
@@ -71,6 +71,9 @@ func (r mariaDBAPIResponse) releaseMap() map[string]mariaDBAPIRelease {
 // GetMariaDBTarballFromAPI returns a new TarballDescription for a MariaDB release
 // discovered via the MariaDB downloads REST API.
 func GetMariaDBTarballFromAPI(version, OS, arch string, minimal bool) (TarballDescription, error) {
+	if minimal {
+		return TarballDescription{}, fmt.Errorf("minimal tarballs are not available for MariaDB Server")
+	}
 	url := buildMariaDBAPIURL(version)
 	apiResponse, err := getMariaDBAPIResponse(url)
 	if err != nil {

--- a/downloads/mariadb_api.go
+++ b/downloads/mariadb_api.go
@@ -169,12 +169,6 @@ func getBestReleaseFromMariaDBResponse(apiResponse mariaDBAPIResponse) (string, 
 	}
 
 	if bestReleaseID == "" {
-		for releaseID, releaseInfo := range releaseMap {
-			return releaseID, releaseInfo, nil
-		}
-	}
-
-	if bestReleaseID == "" {
 		return "", mariaDBAPIRelease{}, fmt.Errorf("could not determine release from MariaDB API response")
 	}
 
@@ -246,7 +240,7 @@ func getTarballDescriptionFromMariaDBFile(apiFile mariaDBAPIFile) (TarballDescri
 		Name:            apiFile.FileName,
 		Checksum:        getPreferredMariaDBChecksum(apiFile.Checksum),
 		OperatingSystem: normalizeDBDeployerOS(valueOrEmpty(apiFile.OS)),
-		Arch:            archNormalize(normalizeMariaDBArch(valueOrEmpty(apiFile.CPU))),
+		Arch:            normalizeMariaDBArch(valueOrEmpty(apiFile.CPU)),
 		Url:             normalizeMariaDBDownloadURL(apiFile.FileDownloadURL),
 		Flavor:          flavor,
 		Minimal:         strings.Contains(strings.ToLower(apiFile.FileName), "minimal"),
@@ -303,7 +297,7 @@ func normalizeMariaDBOS(OS string) string {
 	case "linux":
 		return "Linux"
 	case "darwin", "macos", "osx":
-		return "darwin"
+		return "Darwin"
 	case "windows":
 		return "Windows"
 	default:
@@ -314,7 +308,7 @@ func normalizeMariaDBOS(OS string) string {
 func normalizeMariaDBArch(arch string) string {
 	switch strings.ToLower(arch) {
 	case "x86_64", "x86-64", "amd64":
-		return "x86_64"
+		return "amd64"
 	case "aarch64", "arm64":
 		return "arm64"
 	default:

--- a/downloads/mariadb_api.go
+++ b/downloads/mariadb_api.go
@@ -1,0 +1,331 @@
+// DBDeployer - The MySQL Sandbox
+// Copyright © 2006-2021 Giuseppe Maxia
+// Copyright © 2026 Frédéric Descamps - lefred
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package downloads
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/ProxySQL/dbdeployer/common"
+)
+
+const mariaDBProductID = "mariadb"
+
+// MariaDBRestAPIBaseURL is exported for tests and defaults to the official MariaDB downloads API.
+var MariaDBRestAPIBaseURL = "https://downloads.mariadb.org/rest-api/" + mariaDBProductID
+
+var mariaDBFullVersionRE = regexp.MustCompile(`^\d+\.\d+\.\d+$`)
+
+type mariaDBAPIChecksum struct {
+	MD5Sum    *string `json:"md5sum"`
+	SHA1Sum   *string `json:"sha1sum"`
+	SHA256Sum *string `json:"sha256sum"`
+	SHA512Sum *string `json:"sha512sum"`
+}
+
+type mariaDBAPIFile struct {
+	FileName        string             `json:"file_name"`
+	PackageType     string             `json:"package_type"`
+	OS              *string            `json:"os"`
+	CPU             *string            `json:"cpu"`
+	Checksum        mariaDBAPIChecksum `json:"checksum"`
+	FileDownloadURL string             `json:"file_download_url"`
+}
+
+type mariaDBAPIRelease struct {
+	ReleaseID string           `json:"release_id"`
+	Files     []mariaDBAPIFile `json:"files"`
+}
+
+type mariaDBAPIResponse struct {
+	Releases    map[string]mariaDBAPIRelease `json:"releases"`
+	ReleaseData map[string]mariaDBAPIRelease `json:"release_data"`
+}
+
+func (r mariaDBAPIResponse) releaseMap() map[string]mariaDBAPIRelease {
+	if len(r.Releases) > 0 {
+		return r.Releases
+	}
+	return r.ReleaseData
+}
+
+// GetMariaDBTarballFromAPI returns a new TarballDescription for a MariaDB release
+// discovered via the MariaDB downloads REST API.
+func GetMariaDBTarballFromAPI(version, OS, arch string, minimal bool) (TarballDescription, error) {
+	url := buildMariaDBAPIURL(version)
+	apiResponse, err := getMariaDBAPIResponse(url)
+	if err != nil {
+		return TarballDescription{}, err
+	}
+
+	releaseID, releaseInfo, err := getBestReleaseFromMariaDBResponse(apiResponse)
+	if err != nil {
+		return TarballDescription{}, err
+	}
+
+	apiFile, err := findBestMariaDBFile(releaseInfo.Files, OS, arch, minimal)
+	if err != nil {
+		return TarballDescription{}, fmt.Errorf("no matching MariaDB file for release %s: %s", releaseID, err)
+	}
+
+	tbd, err := getTarballDescriptionFromMariaDBFile(apiFile)
+	if err != nil {
+		return TarballDescription{}, err
+	}
+
+	if tbd.Version == "" {
+		tbd.Version = releaseID
+	}
+	if tbd.ShortVersion == "" {
+		releaseVersionList, shortErr := common.VersionToList(releaseID)
+		if shortErr == nil && len(releaseVersionList) >= 2 {
+			tbd.ShortVersion = fmt.Sprintf("%d.%d", releaseVersionList[0], releaseVersionList[1])
+		}
+	}
+
+	return tbd, nil
+}
+
+func buildMariaDBAPIURL(version string) string {
+	base := strings.TrimSuffix(MariaDBRestAPIBaseURL, "/")
+	if mariaDBFullVersionRE.MatchString(version) {
+		return fmt.Sprintf("%s/%s/", base, version)
+	}
+	return fmt.Sprintf("%s/%s/latest/", base, version)
+}
+
+func getMariaDBAPIResponse(url string) (mariaDBAPIResponse, error) {
+	client := &http.Client{Timeout: 20 * time.Second}
+	// #nosec G107
+	resp, err := client.Get(url)
+	if err != nil {
+		return mariaDBAPIResponse{}, fmt.Errorf("error querying MariaDB API at %s: %s", url, err)
+	}
+	defer func(Body io.ReadCloser) {
+		_ = Body.Close()
+	}(resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		return mariaDBAPIResponse{}, fmt.Errorf("MariaDB API returned status %d for %s", resp.StatusCode, url)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return mariaDBAPIResponse{}, fmt.Errorf("error reading MariaDB API response: %s", err)
+	}
+
+	var apiResponse mariaDBAPIResponse
+	err = json.Unmarshal(body, &apiResponse)
+	if err != nil {
+		return mariaDBAPIResponse{}, fmt.Errorf("error decoding MariaDB API response: %s", err)
+	}
+
+	if len(apiResponse.releaseMap()) == 0 {
+		return mariaDBAPIResponse{}, fmt.Errorf("MariaDB API response did not contain releases or release_data")
+	}
+
+	return apiResponse, nil
+}
+
+func getBestReleaseFromMariaDBResponse(apiResponse mariaDBAPIResponse) (string, mariaDBAPIRelease, error) {
+	bestReleaseID := ""
+	bestRelease := mariaDBAPIRelease{}
+	bestVersionList := []int{0, 0, 0}
+	releaseMap := apiResponse.releaseMap()
+
+	for releaseID, releaseInfo := range releaseMap {
+		releaseVersionList, err := common.VersionToList(releaseID)
+		if err != nil {
+			continue
+		}
+		greaterOrEqual, err := common.GreaterOrEqualVersionList(releaseVersionList, bestVersionList)
+		if err != nil {
+			continue
+		}
+		if greaterOrEqual {
+			bestReleaseID = releaseID
+			bestRelease = releaseInfo
+			bestVersionList = releaseVersionList
+		}
+	}
+
+	if bestReleaseID == "" {
+		for releaseID, releaseInfo := range releaseMap {
+			return releaseID, releaseInfo, nil
+		}
+	}
+
+	if bestReleaseID == "" {
+		return "", mariaDBAPIRelease{}, fmt.Errorf("could not determine release from MariaDB API response")
+	}
+
+	return bestReleaseID, bestRelease, nil
+}
+
+func findBestMariaDBFile(files []mariaDBAPIFile, OS, arch string, minimal bool) (mariaDBAPIFile, error) {
+	if len(files) == 0 {
+		return mariaDBAPIFile{}, fmt.Errorf("no files in release")
+	}
+
+	requestedOS := normalizeMariaDBOS(OS)
+	requestedArch := normalizeMariaDBArch(arch)
+
+	var matches []mariaDBAPIFile
+	for _, fileInfo := range files {
+		if !isMariaDBTarball(fileInfo.FileName) {
+			continue
+		}
+		if minimal && !strings.Contains(strings.ToLower(fileInfo.FileName), "minimal") {
+			continue
+		}
+		fileOS := valueOrEmpty(fileInfo.OS)
+		if requestedOS != "" && !strings.EqualFold(fileOS, requestedOS) {
+			continue
+		}
+		fileCPU := normalizeMariaDBArch(valueOrEmpty(fileInfo.CPU))
+		if requestedArch != "" && fileCPU != "" && fileCPU != requestedArch {
+			continue
+		}
+		matches = append(matches, fileInfo)
+	}
+
+	if len(matches) == 0 && requestedOS == "darwin" {
+		for _, fileInfo := range files {
+			if isMariaDBTarball(fileInfo.FileName) && strings.EqualFold(valueOrEmpty(fileInfo.OS), "Source") {
+				matches = append(matches, fileInfo)
+			}
+		}
+	}
+
+	if len(matches) == 0 {
+		return mariaDBAPIFile{}, fmt.Errorf("no tarball matches OS=%s arch=%s minimal=%v", OS, arch, minimal)
+	}
+
+	for _, fileInfo := range matches {
+		if strings.Contains(strings.ToLower(fileInfo.FileName), "systemd") {
+			return fileInfo, nil
+		}
+	}
+
+	return matches[0], nil
+}
+
+func getTarballDescriptionFromMariaDBFile(apiFile mariaDBAPIFile) (TarballDescription, error) {
+	if apiFile.FileName == "" {
+		return TarballDescription{}, fmt.Errorf("empty filename in MariaDB API response")
+	}
+	if apiFile.FileDownloadURL == "" {
+		return TarballDescription{}, fmt.Errorf("empty download URL in MariaDB API response")
+	}
+
+	flavor, version, shortVersion, err := common.FindTarballInfo(apiFile.FileName)
+	if err != nil {
+		flavor = "mariadb"
+	}
+
+	return TarballDescription{
+		Name:            apiFile.FileName,
+		Checksum:        getPreferredMariaDBChecksum(apiFile.Checksum),
+		OperatingSystem: normalizeDBDeployerOS(valueOrEmpty(apiFile.OS)),
+		Arch:            archNormalize(normalizeMariaDBArch(valueOrEmpty(apiFile.CPU))),
+		Url:             normalizeMariaDBDownloadURL(apiFile.FileDownloadURL),
+		Flavor:          flavor,
+		Minimal:         strings.Contains(strings.ToLower(apiFile.FileName), "minimal"),
+		ShortVersion:    shortVersion,
+		Version:         version,
+	}, nil
+}
+
+func getPreferredMariaDBChecksum(checksum mariaDBAPIChecksum) string {
+	if checksum.SHA512Sum != nil && *checksum.SHA512Sum != "" {
+		return "SHA512:" + *checksum.SHA512Sum
+	}
+	if checksum.SHA256Sum != nil && *checksum.SHA256Sum != "" {
+		return "SHA256:" + *checksum.SHA256Sum
+	}
+	if checksum.SHA1Sum != nil && *checksum.SHA1Sum != "" {
+		return "SHA1:" + *checksum.SHA1Sum
+	}
+	if checksum.MD5Sum != nil && *checksum.MD5Sum != "" {
+		return "MD5:" + *checksum.MD5Sum
+	}
+	return ""
+}
+
+func valueOrEmpty(v *string) string {
+	if v == nil {
+		return ""
+	}
+	return *v
+}
+
+func normalizeMariaDBDownloadURL(url string) string {
+	if strings.HasPrefix(url, "http://") {
+		return "https://" + strings.TrimPrefix(url, "http://")
+	}
+	return url
+}
+
+func normalizeDBDeployerOS(osName string) string {
+	switch strings.ToLower(osName) {
+	case "linux":
+		return "Linux"
+	case "darwin", "macos", "osx":
+		return "Darwin"
+	case "windows":
+		return "Windows"
+	default:
+		return osName
+	}
+}
+
+func normalizeMariaDBOS(OS string) string {
+	switch strings.ToLower(OS) {
+	case "linux":
+		return "Linux"
+	case "darwin", "macos", "osx":
+		return "darwin"
+	case "windows":
+		return "Windows"
+	default:
+		return OS
+	}
+}
+
+func normalizeMariaDBArch(arch string) string {
+	switch strings.ToLower(arch) {
+	case "x86_64", "x86-64", "amd64":
+		return "x86_64"
+	case "aarch64", "arm64":
+		return "arm64"
+	default:
+		return arch
+	}
+}
+
+func isMariaDBTarball(fileName string) bool {
+	lower := strings.ToLower(fileName)
+	if strings.HasSuffix(lower, ".tar.gz") || strings.HasSuffix(lower, ".tar.xz") || strings.HasSuffix(lower, ".tgz") {
+		return true
+	}
+	return false
+}

--- a/downloads/mariadb_api_test.go
+++ b/downloads/mariadb_api_test.go
@@ -1,3 +1,19 @@
+// DBDeployer - The MySQL Sandbox
+// Copyright © 2006-2021 Giuseppe Maxia
+// Copyright © 2026 Frédéric Descamps - lefred
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package downloads
 
 import (

--- a/downloads/mariadb_api_test.go
+++ b/downloads/mariadb_api_test.go
@@ -1,0 +1,214 @@
+package downloads
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestBuildMariaDBAPIURL(t *testing.T) {
+	oldBase := MariaDBRestAPIBaseURL
+	MariaDBRestAPIBaseURL = "https://downloads.mariadb.org/rest-api/mariadb"
+	defer func() { MariaDBRestAPIBaseURL = oldBase }()
+
+	tests := []struct {
+		name    string
+		version string
+		want    string
+	}{
+		{name: "short version", version: "11.4", want: "https://downloads.mariadb.org/rest-api/mariadb/11.4/latest/"},
+		{name: "full version", version: "11.4.10", want: "https://downloads.mariadb.org/rest-api/mariadb/11.4.10/"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildMariaDBAPIURL(tt.version)
+			if got != tt.want {
+				t.Fatalf("buildMariaDBAPIURL() got %q want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetMariaDBTarballFromAPI(t *testing.T) {
+	payload := `{
+		"releases": {
+			"11.4.10": {
+				"release_id": "11.4.10",
+				"files": [
+					{
+						"file_name": "mariadb-11.4.10-linux-systemd-x86_64.tar.gz",
+						"package_type": "gzipped tar file",
+						"os": "Linux",
+						"cpu": "x86_64",
+						"checksum": {
+							"md5sum": "",
+							"sha1sum": "",
+							"sha256sum": "",
+							"sha512sum": "abc123"
+						},
+						"file_download_url": "http://downloads.mariadb.org/rest-api/mariadb/11.4.10/mariadb-11.4.10-linux-systemd-x86_64.tar.gz"
+					},
+					{
+						"file_name": "mariadb-11.4.10.tar.gz",
+						"package_type": "gzipped tar file",
+						"os": "Source",
+						"cpu": null,
+						"checksum": {
+							"md5sum": "",
+							"sha1sum": "",
+							"sha256sum": "",
+							"sha512sum": "def456"
+						},
+						"file_download_url": "http://downloads.mariadb.org/rest-api/mariadb/11.4.10/mariadb-11.4.10.tar.gz"
+					}
+				]
+			}
+		}
+	}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, payload)
+	}))
+	defer server.Close()
+
+	oldBase := MariaDBRestAPIBaseURL
+	MariaDBRestAPIBaseURL = server.URL + "/mariadb"
+	defer func() { MariaDBRestAPIBaseURL = oldBase }()
+
+	tbd, err := GetMariaDBTarballFromAPI("11.4", "linux", "amd64", false)
+	if err != nil {
+		t.Fatalf("GetMariaDBTarballFromAPI() unexpected error: %v", err)
+	}
+
+	if tbd.Name != "mariadb-11.4.10-linux-systemd-x86_64.tar.gz" {
+		t.Fatalf("unexpected Name: %q", tbd.Name)
+	}
+	if tbd.Url != "https://downloads.mariadb.org/rest-api/mariadb/11.4.10/mariadb-11.4.10-linux-systemd-x86_64.tar.gz" {
+		t.Fatalf("unexpected Url: %q", tbd.Url)
+	}
+	if tbd.Checksum != "SHA512:abc123" {
+		t.Fatalf("unexpected Checksum: %q", tbd.Checksum)
+	}
+	if tbd.OperatingSystem != "Linux" {
+		t.Fatalf("unexpected OperatingSystem: %q", tbd.OperatingSystem)
+	}
+	if tbd.Arch != "amd64" {
+		t.Fatalf("unexpected Arch: %q", tbd.Arch)
+	}
+	if tbd.Flavor != "mariadb" {
+		t.Fatalf("unexpected Flavor: %q", tbd.Flavor)
+	}
+	if tbd.ShortVersion != "11.4" {
+		t.Fatalf("unexpected ShortVersion: %q", tbd.ShortVersion)
+	}
+	if tbd.Version != "11.4.10" {
+		t.Fatalf("unexpected Version: %q", tbd.Version)
+	}
+}
+
+func TestGetMariaDBTarballFromAPI_DarwinFallbackToSource(t *testing.T) {
+	payload := `{
+		"releases": {
+			"11.4.10": {
+				"release_id": "11.4.10",
+				"files": [
+					{
+						"file_name": "mariadb-11.4.10.tar.gz",
+						"package_type": "gzipped tar file",
+						"os": "Source",
+						"cpu": null,
+						"checksum": {
+							"md5sum": "",
+							"sha1sum": "",
+							"sha256sum": "",
+							"sha512sum": "def456"
+						},
+						"file_download_url": "http://downloads.mariadb.org/rest-api/mariadb/11.4.10/mariadb-11.4.10.tar.gz"
+					}
+				]
+			}
+		}
+	}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, payload)
+	}))
+	defer server.Close()
+
+	oldBase := MariaDBRestAPIBaseURL
+	MariaDBRestAPIBaseURL = server.URL + "/mariadb"
+	defer func() { MariaDBRestAPIBaseURL = oldBase }()
+
+	tbd, err := GetMariaDBTarballFromAPI("11.4", "darwin", "amd64", false)
+	if err != nil {
+		t.Fatalf("GetMariaDBTarballFromAPI() unexpected error: %v", err)
+	}
+
+	if tbd.Name != "mariadb-11.4.10.tar.gz" {
+		t.Fatalf("unexpected Name: %q", tbd.Name)
+	}
+}
+
+func TestGetMariaDBTarballFromAPI_ReleaseDataKey(t *testing.T) {
+	payload := `{
+		"release_data": {
+			"11.7.2": {
+				"release_id": "11.7.2",
+				"files": [
+					{
+						"file_name": "mariadb-11.7.2-linux-systemd-x86_64.tar.gz",
+						"package_type": "gzipped tar file",
+						"os": "Linux",
+						"cpu": "x86_64",
+						"checksum": {
+							"md5sum": null,
+							"sha1sum": null,
+							"sha256sum": null,
+							"sha512sum": "a527"
+						},
+						"file_download_url": "http://downloads.mariadb.org/rest-api/mariadb/11.7.2/mariadb-11.7.2-linux-systemd-x86_64.tar.gz"
+					},
+					{
+						"file_name": "yum/",
+						"package_type": null,
+						"os": null,
+						"cpu": null,
+						"checksum": {
+							"md5sum": null,
+							"sha1sum": null,
+							"sha256sum": null,
+							"sha512sum": null
+						},
+						"file_download_url": "http://downloads.mariadb.org/rest-api/mariadb/11.7.2/yum/"
+					}
+				]
+			}
+		}
+	}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, payload)
+	}))
+	defer server.Close()
+
+	oldBase := MariaDBRestAPIBaseURL
+	MariaDBRestAPIBaseURL = server.URL + "/mariadb"
+	defer func() { MariaDBRestAPIBaseURL = oldBase }()
+
+	tbd, err := GetMariaDBTarballFromAPI("11.7.2", "linux", "amd64", false)
+	if err != nil {
+		t.Fatalf("GetMariaDBTarballFromAPI() unexpected error: %v", err)
+	}
+
+	if tbd.Name != "mariadb-11.7.2-linux-systemd-x86_64.tar.gz" {
+		t.Fatalf("unexpected Name: %q", tbd.Name)
+	}
+	if tbd.Checksum != "SHA512:a527" {
+		t.Fatalf("unexpected Checksum: %q", tbd.Checksum)
+	}
+}

--- a/downloads/remote_registry.go
+++ b/downloads/remote_registry.go
@@ -27,10 +27,10 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/araddon/dateparse"
 	"github.com/ProxySQL/dbdeployer/common"
 	"github.com/ProxySQL/dbdeployer/defaults"
 	"github.com/ProxySQL/dbdeployer/globals"
+	"github.com/araddon/dateparse"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 )
@@ -271,16 +271,16 @@ func FindOrGuessTarballByVersionFlavorOS(version, flavor, OS, arch string, minim
 		if minimal && OS == "darwin" {
 			return FindOrGuessTarballByVersionFlavorOS(version, flavor, OS, arch, false, newest, guess)
 		}
+		// Use the MariADB Foundation API if we want to download MariaDB Server
+		if flavor == "mariadb" {
+			fmt.Printf("Version %q not found in registry. Attempting to retrieve from MariaDB API...\n", version)
+			return GetMariaDBTarballFromAPI(version, OS, arch, minimal)
+		}
 		// If still no match and the version is allowed for guessing,
 		// retry with --guess enabled so the download URL can be constructed
 		// from templates rather than requiring an exact registry entry.
 		if !guess && isAllowedForGuessing(version) {
 			return FindOrGuessTarballByVersionFlavorOS(version, flavor, OS, arch, minimal, newest, true)
-		}
-                // In case we are trying to download MariaDB, then we use the download REST API
-                if flavor == "mariadb" {
-			fmt.Printf("Version %q not found in registry. Attempting to retrieve from MariaDB API...\n", version)
-			return GetMariaDBTarballFromAPI(version, OS, arch, minimal)
 		}
 		return TarballDescription{}, fmt.Errorf("version %q not found in registry and cannot be guessed", version)
 	}
@@ -611,14 +611,14 @@ func ParseTarballUrlInfo(tarballUrl string) (TarballDescription, error) {
 	minimal := strings.Contains(strings.ToLower(fileName), "minimal")
 
 	return TarballDescription{
-		Name:         fileName,
-		Url:          tarballUrl,
-		Flavor:       flavor,
-		Version:      version,
-		ShortVersion: shortVersion,
+		Name:            fileName,
+		Url:             tarballUrl,
+		Flavor:          flavor,
+		Version:         version,
+		ShortVersion:    shortVersion,
 		OperatingSystem: OS,
-		Arch:         arch,
-		Minimal:      minimal,
+		Arch:            arch,
+		Minimal:         minimal,
 	}, nil
 }
 

--- a/downloads/remote_registry.go
+++ b/downloads/remote_registry.go
@@ -277,6 +277,11 @@ func FindOrGuessTarballByVersionFlavorOS(version, flavor, OS, arch string, minim
 		if !guess && isAllowedForGuessing(version) {
 			return FindOrGuessTarballByVersionFlavorOS(version, flavor, OS, arch, minimal, newest, true)
 		}
+                // In case we are trying to download MariaDB, then we use the download REST API
+                if flavor == "mariadb" {
+			fmt.Printf("Version %q not found in registry. Attempting to retrieve from MariaDB API...\n", version)
+			return GetMariaDBTarballFromAPI(version, OS, arch, minimal)
+		}
 		return TarballDescription{}, fmt.Errorf("version %q not found in registry and cannot be guessed", version)
 	}
 	newestVersion := fmt.Sprintf("%d.%d.%d", newestVersionList[0], newestVersionList[1], newestVersionList[2])


### PR DESCRIPTION
Allo dbdeployer to install any available MariaDB server versions using the MariaDB Foundation REST-API:

```
$ dbdeployer downloads get-by-version 11.7.2  --flavor=mariadb 
Version "11.7.2" not found in registry. Attempting to retrieve from MariaDB API...
Downloading mariadb-11.7.2-linux-systemd-x86_64.tar.gz
File /var/run/media/fred/DATA/workspace/dbdeployer/mariadb-11.7.2-linux-systemd-x86_64.tar.gz downloaded
Checksum matches
```

```
$ dbdeployer downloads get-by-version 13.0 --flavor=mariadb 
Downloading mariadb-13.0.0-linux-systemd-x86_64.tar.gz

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Uses the MariaDB REST API to fetch and resolve release tarballs when not found locally. Automatically selects the best matching release and file for your OS/arch, prefers systemd builds, normalizes OS/arch names, upgrades http to https, and falls back to a source artifact for macOS. Requests for explicit "minimal" MariaDB Server tarballs are rejected.

* **Tests**
  * Added tests for API URL handling, release/file selection, and macOS fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->