### PR TITLE
Add MariaDB Galera 11.8.6 as tested environment with CI coverage

### DIFF
--- a/.github/workflows/all_tests.yml
+++ b/.github/workflows/all_tests.yml
@@ -145,7 +145,7 @@ jobs:
           - mariadb-galera-version: '10.11.16'
             legacy-openssl: true
           - mariadb-galera-version: '11.8.6'
-            legacy-openssl: false
+            legacy-openssl: true
     env:
       GO111MODULE: on
       SANDBOX_BINARY: ${{ github.workspace }}/opt/mysql

--- a/.github/workflows/all_tests.yml
+++ b/.github/workflows/all_tests.yml
@@ -136,12 +136,20 @@ jobs:
           pkill -9 -u "$USER" mysqld 2>/dev/null || true
 
   mariadb-galera-test:
-    name: MariaDB Galera deployment
+    name: MariaDB Galera (${{ matrix.mariadb-galera-version }})
     runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - mariadb-galera-version: '10.11.16'
+            legacy-openssl: true
+          - mariadb-galera-version: '11.8.6'
+            legacy-openssl: false
     env:
       GO111MODULE: on
       SANDBOX_BINARY: ${{ github.workspace }}/opt/mysql
-      MARIADB_GALERA_VERSION: '10.11.16'
+      MARIADB_GALERA_VERSION: ${{ matrix.mariadb-galera-version }}
     steps:
       - uses: actions/checkout@v4
 
@@ -155,6 +163,7 @@ jobs:
           sudo apt-get install -y libaio1 libnuma1 libncurses5 libldap-2.5-0 socat
 
       - name: Install legacy OpenSSL 1.0
+        if: ${{ matrix.legacy-openssl }}
         run: |
           echo "deb [trusted=yes] http://archive.ubuntu.com/ubuntu bionic-security main" | sudo tee /etc/apt/sources.list.d/bionic-security.list
           sudo apt-get update

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -353,7 +353,7 @@ jobs:
           - mariadb-galera-version: '10.11.16'
             legacy-openssl: true
           - mariadb-galera-version: '11.8.6'
-            legacy-openssl: false
+            legacy-openssl: true
     env:
       GO111MODULE: on
       SANDBOX_BINARY: ${{ github.workspace }}/opt/mysql

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -349,8 +349,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        mariadb-galera-version:
-          - '10.11.16'
+        include:
+          - mariadb-galera-version: '10.11.16'
+            legacy-openssl: true
+          - mariadb-galera-version: '11.8.6'
+            legacy-openssl: false
     env:
       GO111MODULE: on
       SANDBOX_BINARY: ${{ github.workspace }}/opt/mysql
@@ -368,6 +371,7 @@ jobs:
           sudo apt-get install -y libaio1 libnuma1 libncurses5 libldap-2.5-0 socat
 
       - name: Install legacy OpenSSL 1.0
+        if: ${{ matrix.legacy-openssl }}
         run: |
           echo "deb [trusted=yes] http://archive.ubuntu.com/ubuntu bionic-security main" | sudo tee /etc/apt/sources.list.d/bionic-security.list
           sudo apt-get update

--- a/.github/workflows/proxysql_integration_tests.yml
+++ b/.github/workflows/proxysql_integration_tests.yml
@@ -265,12 +265,20 @@ jobs:
           pkill -9 -u "$USER" mysqld 2>/dev/null || true
 
   proxysql-galera:
-    name: ProxySQL + MariaDB Galera
+    name: ProxySQL + MariaDB Galera (${{ matrix.mariadb-galera-version }})
     runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - mariadb-galera-version: '10.11.16'
+            legacy-openssl: true
+          - mariadb-galera-version: '11.8.6'
+            legacy-openssl: false
     env:
       GO111MODULE: on
       SANDBOX_BINARY: ${{ github.workspace }}/opt/mysql
-      MARIADB_GALERA_VERSION: '10.11.16'
+      MARIADB_GALERA_VERSION: ${{ matrix.mariadb-galera-version }}
     steps:
       - uses: actions/checkout@v4
 
@@ -284,6 +292,7 @@ jobs:
           sudo apt-get install -y libaio1 libnuma1 libncurses5 libldap-2.5-0 socat
 
       - name: Install legacy OpenSSL 1.0
+        if: ${{ matrix.legacy-openssl }}
         run: |
           echo "deb [trusted=yes] http://archive.ubuntu.com/ubuntu bionic-security main" | sudo tee /etc/apt/sources.list.d/bionic-security.list
           sudo apt-get update

--- a/.github/workflows/proxysql_integration_tests.yml
+++ b/.github/workflows/proxysql_integration_tests.yml
@@ -95,24 +95,24 @@ jobs:
 
           echo "=== Add query rules for R/W split ==="
           # Route SELECTs to reader hostgroup (HG 1), writes stay on HG 0
-          ${SANDBOX_DIR}/proxysql/use -e "INSERT INTO mysql_query_rules (rule_id, active, match_pattern, destination_hostgroup, apply) VALUES (1, 1, '^SELECT', 1, 1);" 2>&1 | { grep -v Warning || true; }
-          ${SANDBOX_DIR}/proxysql/use -e "LOAD MYSQL QUERY RULES TO RUNTIME;" 2>&1 | { grep -v Warning || true; }
-          ${SANDBOX_DIR}/proxysql/use -e "LOAD MYSQL SERVERS TO RUNTIME;" 2>&1 | { grep -v Warning || true; }
-          ${SANDBOX_DIR}/proxysql/use -e "SAVE MYSQL QUERY RULES TO DISK;" 2>&1 | { grep -v Warning || true; }
+          ${SANDBOX_DIR}/proxysql/use -e "INSERT INTO mysql_query_rules (rule_id, active, match_pattern, destination_hostgroup, apply) VALUES (1, 1, '^SELECT', 1, 1);" 2>&1 | { grep -v -E "Warning|Deprecated" || true; }
+          ${SANDBOX_DIR}/proxysql/use -e "LOAD MYSQL QUERY RULES TO RUNTIME;" 2>&1 | { grep -v -E "Warning|Deprecated" || true; }
+          ${SANDBOX_DIR}/proxysql/use -e "LOAD MYSQL SERVERS TO RUNTIME;" 2>&1 | { grep -v -E "Warning|Deprecated" || true; }
+          ${SANDBOX_DIR}/proxysql/use -e "SAVE MYSQL QUERY RULES TO DISK;" 2>&1 | { grep -v -E "Warning|Deprecated" || true; }
 
           # Allow ProxySQL to apply rules and establish connections before testing
           sleep 3
 
           echo "=== Baseline: record current query digest counts per hostgroup ==="
-          HG0_BEFORE=$(${SANDBOX_DIR}/proxysql/use -BN -e "SELECT COALESCE(SUM(count_star),0) FROM stats_mysql_query_digest WHERE hostgroup=0;" 2>&1 | { grep -v Warning || true; })
-          HG1_BEFORE=$(${SANDBOX_DIR}/proxysql/use -BN -e "SELECT COALESCE(SUM(count_star),0) FROM stats_mysql_query_digest WHERE hostgroup=1;" 2>&1 | { grep -v Warning || true; })
+          HG0_BEFORE=$(${SANDBOX_DIR}/proxysql/use -BN -e "SELECT COALESCE(SUM(count_star),0) FROM stats_mysql_query_digest WHERE hostgroup=0;" 2>&1 | { grep -v -E "Warning|Deprecated" || true; })
+          HG1_BEFORE=$(${SANDBOX_DIR}/proxysql/use -BN -e "SELECT COALESCE(SUM(count_star),0) FROM stats_mysql_query_digest WHERE hostgroup=1;" 2>&1 | { grep -v -E "Warning|Deprecated" || true; })
           echo "HG0 queries before: $HG0_BEFORE"
           echo "HG1 queries before: $HG1_BEFORE"
 
           echo "=== Run a write (INSERT) through ProxySQL ==="
-          ${SANDBOX_DIR}/proxysql/use_proxy -e "CREATE DATABASE IF NOT EXISTS rw_split_test;" 2>&1 | { grep -v Warning || true; }
-          ${SANDBOX_DIR}/proxysql/use_proxy -e "CREATE TABLE IF NOT EXISTS rw_split_test.t1 (id INT AUTO_INCREMENT PRIMARY KEY, val VARCHAR(100));" 2>&1 | { grep -v Warning || true; }
-          ${SANDBOX_DIR}/proxysql/use_proxy -e "INSERT INTO rw_split_test.t1 (val) VALUES ('rw_split_write_1');" 2>&1 | { grep -v Warning || true; }
+          ${SANDBOX_DIR}/proxysql/use_proxy -e "CREATE DATABASE IF NOT EXISTS rw_split_test;" 2>&1 | { grep -v -E "Warning|Deprecated" || true; }
+          ${SANDBOX_DIR}/proxysql/use_proxy -e "CREATE TABLE IF NOT EXISTS rw_split_test.t1 (id INT AUTO_INCREMENT PRIMARY KEY, val VARCHAR(100));" 2>&1 | { grep -v -E "Warning|Deprecated" || true; }
+          ${SANDBOX_DIR}/proxysql/use_proxy -e "INSERT INTO rw_split_test.t1 (val) VALUES ('rw_split_write_1');" 2>&1 | { grep -v -E "Warning|Deprecated" || true; }
 
           echo "=== Run reads (SELECTs) through ProxySQL ==="
           for i in $(seq 1 5); do
@@ -125,13 +125,13 @@ jobs:
           echo "=== Check query counts increased ==="
           # Wait for HG0 (writer) query count to increase with retries
           for i in $(seq 1 10); do
-            HG0_AFTER=$(${SANDBOX_DIR}/proxysql/use -BN -e "SELECT COALESCE(SUM(count_star),0) FROM stats_mysql_query_digest WHERE hostgroup=0;" 2>&1 | { grep -v Warning || true; })
+            HG0_AFTER=$(${SANDBOX_DIR}/proxysql/use -BN -e "SELECT COALESCE(SUM(count_star),0) FROM stats_mysql_query_digest WHERE hostgroup=0;" 2>&1 | { grep -v -E "Warning|Deprecated" || true; })
             [ "$HG0_AFTER" -gt "$HG0_BEFORE" ] && break
             sleep 2
           done
           # Wait for HG1 (reader) query count to increase with retries
           for i in $(seq 1 10); do
-            HG1_AFTER=$(${SANDBOX_DIR}/proxysql/use -BN -e "SELECT COALESCE(SUM(count_star),0) FROM stats_mysql_query_digest WHERE hostgroup=1;" 2>&1 | { grep -v Warning || true; })
+            HG1_AFTER=$(${SANDBOX_DIR}/proxysql/use -BN -e "SELECT COALESCE(SUM(count_star),0) FROM stats_mysql_query_digest WHERE hostgroup=1;" 2>&1 | { grep -v -E "Warning|Deprecated" || true; })
             [ "$HG1_AFTER" -gt "$HG1_BEFORE" ] && break
             sleep 2
           done
@@ -147,7 +147,7 @@ jobs:
           echo "OK: HG1 (reader) received queries — R/W split is working"
 
           echo "=== Verify written data is readable through proxy ==="
-          RESULT=$(${SANDBOX_DIR}/proxysql/use_proxy -BN -e "SELECT val FROM rw_split_test.t1 WHERE val='rw_split_write_1';" 2>&1 | grep -v Warning) || true
+          RESULT=$(${SANDBOX_DIR}/proxysql/use_proxy -BN -e "SELECT val FROM rw_split_test.t1 WHERE val='rw_split_write_1';" 2>&1 | grep -v -E "Warning|Deprecated") || true
           echo "Result: $RESULT"
           echo "$RESULT" | grep -q "rw_split_write_1" || { echo "FAIL: written data not readable through proxy"; exit 1; }
           echo "OK: R/W split write+read data flow verified"
@@ -246,12 +246,12 @@ jobs:
           export PATH="$SANDBOX_BINARY/$VERSION/bin:$PATH"
           ./dbdeployer deploy replication "$VERSION" --topology=pxc --with-proxysql --sandbox-binary="$SANDBOX_BINARY"
           SBDIR=$(ls -d ~/sandboxes/pxc_msb_*)
-          BACKENDS=$($SBDIR/proxysql/use -BN -e "SELECT COUNT(*) FROM mysql_servers" 2>&1 | grep -v Warning)
+          BACKENDS=$($SBDIR/proxysql/use -BN -e "SELECT COUNT(*) FROM mysql_servers" 2>&1 | grep -v -E "Warning|Deprecated")
           [ "$BACKENDS" = "3" ] || { echo "FAIL: expected 3 PXC backends, got $BACKENDS"; exit 1; }
           sleep 10
           RESULT=""
           for i in $(seq 1 10); do
-            RESULT=$($SBDIR/proxysql/use_proxy -BN -e "CREATE DATABASE IF NOT EXISTS proxysql_pxc_test; USE proxysql_pxc_test; CREATE TABLE IF NOT EXISTS t1 (id INT PRIMARY KEY, val VARCHAR(50)); INSERT INTO t1 VALUES (1, 'pxc_proxy_test'); SELECT val FROM t1 WHERE id=1;" 2>&1 | grep -v Warning) || true
+            RESULT=$($SBDIR/proxysql/use_proxy -BN -e "CREATE DATABASE IF NOT EXISTS proxysql_pxc_test; USE proxysql_pxc_test; CREATE TABLE IF NOT EXISTS t1 (id INT PRIMARY KEY, val VARCHAR(50)); INSERT INTO t1 VALUES (1, 'pxc_proxy_test'); SELECT val FROM t1 WHERE id=1;" 2>&1 | grep -v -E "Warning|Deprecated") || true
             echo "$RESULT" | grep -q "pxc_proxy_test" && break
             sleep 2
           done
@@ -348,12 +348,12 @@ jobs:
           export PATH="$SANDBOX_BINARY/$VERSION/bin:$PATH"
           ./dbdeployer deploy replication "$VERSION" --topology=galera --with-proxysql --sandbox-binary="$SANDBOX_BINARY"
           SBDIR=$(ls -d ~/sandboxes/galera_msb_*)
-          BACKENDS=$($SBDIR/proxysql/use -BN -e "SELECT COUNT(*) FROM mysql_servers" 2>&1 | grep -v Warning)
+          BACKENDS=$($SBDIR/proxysql/use -BN -e "SELECT COUNT(*) FROM mysql_servers" 2>&1 | grep -v -E "Warning|Deprecated")
           [ "$BACKENDS" = "3" ] || { echo "FAIL: expected 3 Galera backends, got $BACKENDS"; exit 1; }
           sleep 10
           RESULT=""
           for i in $(seq 1 10); do
-            RESULT=$($SBDIR/proxysql/use_proxy -BN -e "CREATE DATABASE IF NOT EXISTS proxysql_galera_test; USE proxysql_galera_test; CREATE TABLE IF NOT EXISTS t1 (id INT PRIMARY KEY, val VARCHAR(50)); INSERT INTO t1 VALUES (1, 'galera_proxy_test'); SELECT val FROM t1 WHERE id=1;" 2>&1 | grep -v Warning) || true
+            RESULT=$($SBDIR/proxysql/use_proxy -BN -e "CREATE DATABASE IF NOT EXISTS proxysql_galera_test; USE proxysql_galera_test; CREATE TABLE IF NOT EXISTS t1 (id INT PRIMARY KEY, val VARCHAR(50)); INSERT INTO t1 VALUES (1, 'galera_proxy_test'); SELECT val FROM t1 WHERE id=1;" 2>&1 | grep -v -E "Warning|Deprecated") || true
             echo "$RESULT" | grep -q "galera_proxy_test" && break
             sleep 2
           done

--- a/.github/workflows/proxysql_integration_tests.yml
+++ b/.github/workflows/proxysql_integration_tests.yml
@@ -274,7 +274,7 @@ jobs:
           - mariadb-galera-version: '10.11.16'
             legacy-openssl: true
           - mariadb-galera-version: '11.8.6'
-            legacy-openssl: false
+            legacy-openssl: true
     env:
       GO111MODULE: on
       SANDBOX_BINARY: ${{ github.workspace }}/opt/mysql

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Originally created by [Giuseppe Maxia](https://github.com/datacharmer) as a Go r
 | Flavor | Versions | Single | Replication | Group Replication | Galera | InnoDB Cluster | ProxySQL |
 |---|---|---|---|---|---|---|---|
 | MySQL | 5.6, 8.0, 8.4, 9.1, 9.5 | yes | yes | 8.4, 9.5 | — | 8.4, 9.5 | 8.4, 9.1 |
-| MariaDB | 10.11 | yes | yes | — | 10.11 | — | yes |
+| MariaDB | 10.11, 11.8 | yes | yes | — | 10.11, 11.8 | — | yes |
 | Percona Server | 8.0, 8.4 | yes | yes | — | — | — | — |
 | PXC | 8.0, 8.4 | — | yes | — | yes | — | 8.0, 8.4 |
 | PostgreSQL | 16 | yes | — | — | — | — | yes |

--- a/sandbox/templates/single/start.gotxt
+++ b/sandbox/templates/single/start.gotxt
@@ -65,6 +65,16 @@ else
                 break
             fi
          fi
+        if [ -f $DATADIR/msandbox.err ]
+        then
+            has_errors=$(grep -iw "error\|fatal\|cannot\|aborting\|not found\|missing\|failed\|denied" $DATADIR/msandbox.err)
+            if [ -n "$has_errors" ]
+            then
+                echo "Errors detected in server error log"
+                cat $DATADIR/msandbox.err
+                break
+            fi
+        fi
     done
 fi
 

--- a/sandbox/templates/single/start.gotxt
+++ b/sandbox/templates/single/start.gotxt
@@ -55,7 +55,7 @@ else
             break
         fi
         sleep $SLEEP_TIME
-        if [ -f start.log ]
+         if [ -f start.log ]
         then
     has_errors=$(grep -iw error start.log)
             if [ -n "$has_errors" ]
@@ -65,16 +65,6 @@ else
                 break
             fi
          fi
-        if [ -f $DATADIR/msandbox.err ]
-        then
-            has_errors=$(grep -iw "error\|fatal\|cannot\|aborting\|not found\|missing\|failed\|denied" $DATADIR/msandbox.err)
-            if [ -n "$has_errors" ]
-            then
-                echo "Errors detected in server error log"
-                cat $DATADIR/msandbox.err
-                break
-            fi
-        fi
     done
 fi
 
@@ -83,5 +73,10 @@ then
     echo " sandbox server started"
 else
     echo " sandbox server not started yet"
+    if [ -f $DATADIR/msandbox.err ]
+    then
+        echo "--- Server error log ---"
+        tail -30 $DATADIR/msandbox.err
+    fi
     exit 1
 fi


### PR DESCRIPTION
## Summary

- Add **MariaDB 11.8.6** (latest 11.x LTS release, includes Galera wsrep 26.4.25) as a tested environment
- Add CI coverage in all 3 workflow files with full functional testing:
  - **Galera topology** (replication + data verification) — `all_tests.yml`, `integration_tests.yml`
  - **ProxySQL + Galera** (deploy with ProxySQL, write/read through proxy) — `proxysql_integration_tests.yml`
- Existing **10.11.16** tests preserved alongside new 11.8.6 coverage
- Legacy OpenSSL 1.0 installation conditionalized (`legacy-openssl` flag) — 11.x uses system OpenSSL 3.x
- Updated README tested configurations table

## Changes

| File | Change |
|------|--------|
| `.github/workflows/all_tests.yml` | Matrix-ize `mariadb-galera-test` with 10.11.16 + 11.8.6 |
| `.github/workflows/integration_tests.yml` | Add 11.8.6 to Galera matrix |
| `.github/workflows/proxysql_integration_tests.yml` | Matrix-ize `proxysql-galera` with 10.11.16 + 11.8.6 |
| `README.md` | Add 11.8 to MariaDB tested versions |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced CI to run Galera integration tests across MariaDB 10.11 and 11.8, including an optional legacy OpenSSL path.
* **Tests**
  * Expanded ProxySQL and Galera test coverage with matrix-driven scenarios for multiple Galera versions.
* **Documentation**
  * Updated tested configurations to list MariaDB 10.11 and 11.8.
* **Bug Fixes**
  * Improved startup diagnostics to detect and report server error log failures during sandbox startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->