### PR TITLE
fix: actionable instructions when sandbox-binary directory is missing

### DIFF
--- a/cmd/unpack.go
+++ b/cmd/unpack.go
@@ -68,7 +68,11 @@ func unpackTarball(cmd *cobra.Command, args []string) {
 	if !common.DirExists(Basedir) {
 		common.Exit(1,
 			fmt.Sprintf(globals.ErrDirectoryNotFound, Basedir),
-			"You should create it or provide an alternate base directory using --sandbox-binary")
+			"Create it by running:",
+			"    dbdeployer init --skip-all-downloads",
+			"or manually with:",
+			fmt.Sprintf("    mkdir -p %s", Basedir),
+			"or provide an alternate base directory using --sandbox-binary")
 	}
 
 	err = ops.UnpackTarball(ops.UnpackOptions{


### PR DESCRIPTION
## Summary

- Closes #110.
- When `dbdeployer unpack` fails because `$HOME/opt/mysql` (or a custom `--sandbox-binary`) doesn't exist, the error now tells the user exactly how to fix it instead of just saying "You should create it".
- Points to `dbdeployer init --skip-all-downloads` (the canonical setup command) and includes a copy-pasteable `mkdir -p <basedir>` as a manual alternative.
- No automatic side effects: directory is still not created on the user's behalf.

### Before

```
directory '/Users/username/opt/mysql' not found
You should create it or provide an alternate base directory using --sandbox-binary
```

### After

```
directory '/Users/username/opt/mysql' not found
Create it by running:
    dbdeployer init --skip-all-downloads
or manually with:
    mkdir -p /Users/username/opt/mysql
or provide an alternate base directory using --sandbox-binary
```

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./cmd/... ./unpack/...` passes
- [x] Manually verified with a clean `HOME`: error text matches the "After" block above and exit code is still 1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error messaging when the sandbox binary directory is missing, now providing explicit guidance with multiple resolution options including initialization commands and directory creation methods.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ProxySQL/dbdeployer/pull/114)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->