### PR TITLE
fix: usable error when install-script deps are missing; prefer sha256sum

### DIFF
--- a/scripts/dbdeployer-install.sh
+++ b/scripts/dbdeployer-install.sh
@@ -69,16 +69,59 @@ then
   exit 1
 fi
 
-# (STEP 2) checks that the needed tools are installed in the system
-for tool in tar curl gzip shasum
+# (STEP 2) checks that the needed tools are installed in the system.
+# For the checksum verification we accept either `sha256sum` (preinstalled
+# on most Linux distros via coreutils) or `shasum` (preinstalled on macOS).
+# All missing tools are collected and reported together with install hints,
+# so the user only has to install once and re-run.
+missing_tools=()
+for tool in tar curl gzip
 do
-    found_tool=$(exists_in_path $tool)
-    if [ -z "$found_tool" ]
+    if [ -z "$(exists_in_path "$tool")" ]
     then
-        echo "tool '$tool' not found"
-        exit 1
+        missing_tools+=("$tool")
     fi
 done
+
+# Pick a checksum command: prefer sha256sum (Linux default), fall back to shasum (macOS default).
+checksum_cmd=""
+if [ -n "$(exists_in_path sha256sum)" ]
+then
+    checksum_cmd="sha256sum -c -"
+elif [ -n "$(exists_in_path shasum)" ]
+then
+    checksum_cmd="shasum -a 256 -c -"
+else
+    missing_tools+=("sha256sum-or-shasum")
+fi
+
+if [ "${#missing_tools[@]}" -ne 0 ]
+then
+    echo "Required tool(s) not found in \$PATH:"
+    for tool in "${missing_tools[@]}"
+    do
+        case "$tool" in
+            tar|curl|gzip)
+                echo "  - $tool"
+                echo "      Debian/Ubuntu: sudo apt-get install -y $tool"
+                echo "      RHEL/Fedora:   sudo dnf install -y $tool"
+                echo "      Alpine:        sudo apk add $tool"
+                echo "      macOS:         preinstalled"
+                ;;
+            sha256sum-or-shasum)
+                echo "  - sha256sum (GNU coreutils) or shasum (Perl Digest::SHA)"
+                echo "      Debian/Ubuntu: sudo apt-get install -y coreutils           # provides sha256sum"
+                echo "                  or sudo apt-get install -y libdigest-sha-perl  # provides shasum"
+                echo "      RHEL/Fedora:   sudo dnf install -y coreutils               # provides sha256sum"
+                echo "                  or sudo dnf install -y perl-Digest-SHA         # provides shasum"
+                echo "      Alpine:        sudo apk add coreutils                      # provides sha256sum"
+                echo "                  or sudo apk add perl-utils                     # provides shasum"
+                echo "      macOS:         shasum is preinstalled"
+                ;;
+        esac
+    done
+    exit 1
+fi
 
 # (STEP 3) collects the latest version from GitHub
 dbdeployer_version=$(curl -s $version_url | grep '"tag_name"' | sed -E 's/.*"v([^"]+)".*/\1/')
@@ -167,8 +210,9 @@ then
 fi
 
 # (STEP 10) probes the checksum (extract the line for our file from checksums.txt)
-grep "$filename" "$checksum_file" | shasum -a 256 -c -
-check_exit_code "shasum -c for $filename"
+# $checksum_cmd was selected in STEP 2 — either `sha256sum -c -` or `shasum -a 256 -c -`.
+grep "$filename" "$checksum_file" | $checksum_cmd
+check_exit_code "checksum verification for $filename"
 
 # (STEP 11) unpacks the archive
 tar -xzf "$filename"


### PR DESCRIPTION
## Summary

Addresses #111. Three improvements to `scripts/dbdeployer-install.sh`:

1. **Prefer `sha256sum`, fall back to `shasum`.** The script previously required `shasum` (a Perl utility default on macOS, not on Linux). On Ubuntu 24.04 minimal images this was the only missing tool — but `sha256sum` from GNU coreutils is preinstalled there. Both tools produce/consume the same `<hex>  <filename>` checksum format used in `checksums.txt`, so the verification step works with either. This removes the failure mode entirely on Linux without forcing the user to install anything.
2. **Report all missing tools at once.** The old loop exited on the first missing tool, so a user with two missing deps would have to install, re-run, install, re-run. We now collect every missing required tool (`tar`, `curl`, `gzip`, and a checksum tool if neither `sha256sum` nor `shasum` is present) and print them all together before exiting.
3. **Per-tool install hints for the common platforms.** For each missing tool we print the install command for Debian/Ubuntu, RHEL/Fedora, Alpine, and macOS — so the user knows exactly what to install instead of just "tool 'X' not found".

### Before (issue #111 reproducer on Ubuntu 24.04)

```
$ curl -s .../dbdeployer-install.sh | bash
tool 'shasum' not found
```

### After

On Ubuntu 24.04: succeeds — `sha256sum` is preinstalled and used automatically.

If a tool *is* missing, the user sees something like:

```
Required tool(s) not found in $PATH:
  - tar
      Debian/Ubuntu: sudo apt-get install -y tar
      RHEL/Fedora:   sudo dnf install -y tar
      Alpine:        sudo apk add tar
      macOS:         preinstalled
  - sha256sum (GNU coreutils) or shasum (Perl Digest::SHA)
      Debian/Ubuntu: sudo apt-get install -y coreutils           # provides sha256sum
                  or sudo apt-get install -y libdigest-sha-perl  # provides shasum
      RHEL/Fedora:   sudo dnf install -y coreutils               # provides sha256sum
                  or sudo dnf install -y perl-Digest-SHA         # provides shasum
      Alpine:        sudo apk add coreutils                      # provides sha256sum
                  or sudo apk add perl-utils                     # provides shasum
      macOS:         shasum is preinstalled
```

## Test plan

- [x] `bash -n scripts/dbdeployer-install.sh` — syntax OK
- [x] Simulated Ubuntu 24.04 (`sha256sum` present, `shasum` missing): script proceeds, `checksum_cmd` selects `sha256sum -c -`
- [x] Simulated fully empty `$PATH`: all four tools reported together with hints, exit code 1
- [x] Verified `shasum -a 256` and `sha256sum` produce a mutually-compatible `<hex>  <file>` file format, so `sha256sum -c` accepts the existing release `checksums.txt`
- [x] CI install-script matrix (`ubuntu-22.04`, `ubuntu-24.04`, `macos-14`, `macos-15`) all have at least one of `sha256sum`/`shasum` preinstalled, so `install_script_test.yml` continues to pass

## Notes

The change does not attempt distro auto-detection — keeping a `/etc/os-release` parse out of the install script avoids adding maintenance burden the rest of the file doesn't have. The hints are short enough that users can self-select.