### PR TITLE
fix(postgresql): place deb-extracted binaries at lib/postgresql/<major>/bin so PG can relocate sharedir

### DIFF
--- a/providers/postgresql/sandbox.go
+++ b/providers/postgresql/sandbox.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 
 	"github.com/ProxySQL/dbdeployer/providers"
 )
@@ -19,6 +20,10 @@ func (p *PostgreSQLProvider) CreateSandbox(config providers.SandboxConfig) (*pro
 	dataDir := filepath.Join(config.Dir, "data")
 	logDir := filepath.Join(dataDir, "log")
 	logFile := filepath.Join(config.Dir, "postgresql.log")
+
+	if err := checkLinuxLayout(basedir, binDir); err != nil {
+		return nil, err
+	}
 
 	replication := config.Options["replication"] == "true"
 
@@ -93,4 +98,36 @@ func (p *PostgreSQLProvider) resolveBasedir(config providers.SandboxConfig) (str
 		return bd, nil
 	}
 	return basedirFromVersion(config.Version)
+}
+
+// checkLinuxLayout detects PostgreSQL extractions produced by older
+// versions of dbdeployer (before issue #112 was fixed). In the old layout,
+// <basedir>/bin/<binary> were regular files; PG's make_relative_path() then
+// failed to relocate the compiled-in SHAREDIR (`/usr/share/postgresql/<major>`),
+// so initdb died with "could not open directory /usr/share/postgresql/<major>/timezonesets".
+//
+// New extractions place the real binaries under
+// <basedir>/lib/postgresql/<major>/bin/ and expose them via symlinks at
+// <basedir>/bin/. If we find a regular file there on Linux, the user
+// needs to re-run unpack.
+func checkLinuxLayout(basedir, binDir string) error {
+	if runtime.GOOS != "linux" {
+		return nil
+	}
+	fi, err := os.Lstat(filepath.Join(binDir, "postgres"))
+	if err != nil {
+		// Missing binary will be reported by the initdb step below with a
+		// clearer error than we could produce here.
+		return nil
+	}
+	if fi.Mode()&os.ModeSymlink != 0 {
+		return nil
+	}
+	return fmt.Errorf(
+		"PostgreSQL binaries at %s were unpacked by an older dbdeployer using\n"+
+			"a layout incompatible with deb-packaged PostgreSQL — initdb would fail\n"+
+			"to find share files (see issue #112). Re-run unpack to fix:\n"+
+			"    dbdeployer unpack --provider=postgresql <server.deb> <client.deb>",
+		basedir,
+	)
 }

--- a/providers/postgresql/unpack.go
+++ b/providers/postgresql/unpack.go
@@ -63,23 +63,50 @@ func UnpackDebs(serverDeb, clientDeb, targetDir string) error {
 	major := strings.Split(version, ".")[0]
 
 	srcBin := filepath.Join(tmpDir, "usr", "lib", "postgresql", major, "bin")
-	srcLib := filepath.Join(tmpDir, "usr", "lib", "postgresql", major, "lib")
+	srcPgLib := filepath.Join(tmpDir, "usr", "lib", "postgresql", major, "lib")
 	srcShare := filepath.Join(tmpDir, "usr", "share", "postgresql", major)
 
-	dstBin := filepath.Join(targetDir, "bin")
-	dstLib := filepath.Join(targetDir, "lib")
-	dstShare := filepath.Join(targetDir, "share")
+	// Destination layout mirrors Debian's compile-time prefix so that PG's
+	// make_relative_path() (src/port/path.c) succeeds at runtime. Debian
+	// builds PG with BINDIR=/usr/lib/postgresql/<major>/bin and
+	// SHAREDIR=/usr/share/postgresql/<major>; the common prefix is just
+	// /usr/, so for PG to relocate SHAREDIR to <basedir>/share/postgresql/<major>
+	// the running binary's parent directory must end in
+	// "lib/postgresql/<major>/bin". Same logic applies to PKGLIBDIR.
+	//
+	// We therefore place the real binaries and extension libs under
+	// <basedir>/lib/postgresql/<major>/, and expose them via symlinks at
+	// <basedir>/bin/ so existing callers (sandbox.go, scripts.go) keep
+	// working. On Linux, PG's find_my_exec() reads /proc/self/exe which
+	// resolves symlinks to the real file, so launching via the symlink
+	// still gives PG the relocatable path it needs.
+	dstPgBin := filepath.Join(targetDir, "lib", "postgresql", major, "bin")
+	dstPgLib := filepath.Join(targetDir, "lib", "postgresql", major, "lib")
+	dstShare := filepath.Join(targetDir, "share")                       // flat, for `initdb -L`
+	dstPgShare := filepath.Join(targetDir, "share", "postgresql", major) // nested, for postgres runtime
+	dstBin := filepath.Join(targetDir, "bin")                           // symlinks into dstPgBin
 
-	for _, dir := range []string{dstBin, dstLib, dstShare} {
+	// Make UnpackDebs idempotent: remove any prior extraction artifacts
+	// in the subtrees we own so re-running unpack picks up the latest
+	// layout cleanly (in particular when migrating from a pre-fix layout
+	// where <basedir>/bin/<binary> were real files instead of symlinks).
+	for _, dir := range []string{dstBin, filepath.Join(targetDir, "lib"), dstShare} {
+		if err := os.RemoveAll(dir); err != nil {
+			return fmt.Errorf("removing stale %s: %w", dir, err)
+		}
+	}
+
+	for _, dir := range []string{dstPgBin, dstPgLib, dstShare, dstPgShare, dstBin} {
 		if err := os.MkdirAll(dir, 0755); err != nil {
 			return fmt.Errorf("creating directory %s: %w", dir, err)
 		}
 	}
 
 	copies := []struct{ src, dst string }{
-		{srcBin, dstBin},
-		{srcLib, dstLib},
-		{srcShare, dstShare},
+		{srcBin, dstPgBin},
+		{srcPgLib, dstPgLib},
+		{srcShare, dstShare},   // flat copy for `initdb -L`
+		{srcShare, dstPgShare}, // nested copy for postgres server runtime
 	}
 	for _, c := range copies {
 		if _, err := os.Stat(c.src); os.IsNotExist(err) {
@@ -91,17 +118,21 @@ func UnpackDebs(serverDeb, clientDeb, targetDir string) error {
 		}
 	}
 
-	// The postgres binary resolves share data relative to its own binary as
-	// ../share/postgresql/<major>/ (compiled-in prefix from deb packaging).
-	// Copy share files there too so both initdb (-L share/) and the postgres
-	// server binary can find timezonesets and other share data.
-	pgShareCompat := filepath.Join(dstShare, "postgresql", major)
-	if err := os.MkdirAll(pgShareCompat, 0755); err != nil {
-		return fmt.Errorf("creating compat share dir: %w", err)
+	// Expose every server-side binary as <basedir>/bin/<name>, symlinked
+	// into the nested lib/postgresql/<major>/bin/ directory.
+	entries, err := os.ReadDir(dstPgBin)
+	if err != nil {
+		return fmt.Errorf("reading %s: %w", dstPgBin, err)
 	}
-	compatCmd := exec.Command("cp", "-a", srcShare+"/.", pgShareCompat+"/") //nolint:gosec // paths are from controlled deb extraction
-	if output, err := compatCmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("copying share to compat path: %s: %w", string(output), err)
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		linkTarget := filepath.Join("..", "lib", "postgresql", major, "bin", entry.Name())
+		linkPath := filepath.Join(dstBin, entry.Name())
+		if err := os.Symlink(linkTarget, linkPath); err != nil {
+			return fmt.Errorf("symlinking %s -> %s: %w", linkPath, linkTarget, err)
+		}
 	}
 
 	for _, bin := range RequiredBinaries() {


### PR DESCRIPTION
## Summary

Closes #112.

PostgreSQL's deb packages are compiled with the unusual split layout `BINDIR=/usr/lib/postgresql/<major>/bin`, `SHAREDIR=/usr/share/postgresql/<major>`. At runtime PG uses `make_relative_path()` (`src/port/path.c`) to relocate SHAREDIR and PKGLIBDIR relative to the running binary — but only if the binary's parent directory matches the bin_path tail after stripping the common prefix with target_path. For these compiled-in paths the common prefix is just `/usr/`, so the binary's parent must end in `lib/postgresql/<major>/bin`.

dbdeployer previously placed the binaries at `<basedir>/bin/`, so the tail match failed and PG fell back to the absolute compiled-in path `/usr/share/postgresql/<major>` — which doesn't exist on a clean machine without `postgresql-common` installed. `initdb` then died with:

```
FATAL: could not open directory "/usr/share/postgresql/16/timezonesets"
```

The existing code already double-copied share into both `<basedir>/share/` (for `initdb -L`) and `<basedir>/share/postgresql/<major>/` (for runtime relocation) — half the puzzle. The missing half was the binary placement.

## Changes

**`providers/postgresql/unpack.go`**
- Real binaries go to `<basedir>/lib/postgresql/<major>/bin/`.
- Extension libs (PKGLIBDIR) go to `<basedir>/lib/postgresql/<major>/lib/`.
- `<basedir>/bin/<binary>` are now relative symlinks into the nested `bin/`. On Linux `find_my_exec()` reads `/proc/self/exe` which resolves symlinks to the real file, so launching via the symlink still gives PG the relocatable path it needs. Existing callers (`sandbox.go`, `scripts.go`) reach binaries via `<basedir>/bin/` as before — no API change for them.
- `UnpackDebs` is now idempotent: it removes any prior `bin/`, `lib/`, `share/` artifacts before recreating them, so users can re-run unpack to migrate from the old (broken) layout to the new one without a separate flag.

**`providers/postgresql/sandbox.go`**
- New `checkLinuxLayout()` runs at the top of `CreateSandbox`. On Linux, if `<basedir>/bin/postgres` is a regular file (rather than the new symlink), it returns an error pointing the user at `dbdeployer unpack` to fix the layout. This replaces the cryptic `/usr/share/postgresql/16/timezonesets` error with an actionable one.

**macOS path is intentionally unchanged.** Postgres.app's PG is compiled with the standard `--prefix` layout where `BINDIR=<prefix>/bin` and `SHAREDIR=<prefix>/share/postgresql`, so the common prefix covers the whole `<prefix>/` and the bin tail is just `bin` — which dbdeployer's `<basedir>/bin/` already satisfies. The macos-14/macos-15 CI matrix already exercises this end-to-end on a clean runner and was unaffected.

## Test plan

- [x] `go build ./...` clean.
- [x] `go test ./providers/postgresql/... ./cmd/... ./unpack/...` passes.
- [x] **Issue #112 reproducer end-to-end:** `apt-get download postgresql-16 postgresql-client-16 && ./dbdeployer unpack --provider=postgresql ... && ./dbdeployer deploy postgresql 16.13` succeeds (initdb completes, sandbox starts, `SELECT version()` returns `PostgreSQL 16.13 ... on x86_64-pc-linux-gnu`, clean shutdown). On master this fails with the timezonesets error.
- [x] **Old-layout detection:** replaced the symlink at `<basedir>/bin/postgres` with a copy of the real file (simulating a pre-fix extraction); subsequent `dbdeployer deploy postgresql 16.13` returns the new error pointing the user to re-run unpack.
- [x] **Idempotent recovery:** with the simulated old layout in place, re-running `dbdeployer unpack --provider=postgresql ...` cleans the stale `bin/postgres` regular file, lays down the new symlink layout, and the subsequent `deploy` succeeds.

## Follow-up

The current CI for `postgresql-test` in `integration_tests.yml` installs `postgresql-16` system-wide *before* unpacking the debs into `~/opt/postgresql/`. That creates `/usr/share/postgresql/16/` on the runner, which masks this bug — PG falls back to the absolute compiled-in path and finds it. A follow-up PR will switch CI to `apt-get download` only (no `apt-get install`) so the test exercises the actual user flow on a system without `/usr/share/postgresql/16/`. That PR will only land cleanly with this fix in place.