### PR TITLE
fix(postgresql): avoid port collisions across single/replication/multiple deploys

### DIFF
--- a/cmd/deploy_postgresql.go
+++ b/cmd/deploy_postgresql.go
@@ -48,12 +48,14 @@ func deploySandboxPostgreSQL(cmd *cobra.Command, args []string) {
 	if err != nil {
 		common.Exitf(1, "error computing port: %s", err)
 	}
-	freePort, portErr := common.FindFreePort(port, []int{}, 1)
+
+	sandboxHome := defaults.Defaults().SandboxHome
+	installedPorts, _ := common.GetInstalledPorts(sandboxHome)
+	freePort, portErr := common.FindFreePort(port, installedPorts, 1)
 	if portErr == nil {
 		port = freePort
 	}
 
-	sandboxHome := defaults.Defaults().SandboxHome
 	sandboxDir := path.Join(sandboxHome, fmt.Sprintf("pg_sandbox_%d", port))
 
 	if common.DirExists(sandboxDir) {

--- a/cmd/multiple.go
+++ b/cmd/multiple.go
@@ -64,7 +64,15 @@ func deployMultipleNonMySQL(cmd *cobra.Command, args []string, providerName stri
 	}
 
 	sandboxHome := defaults.Defaults().SandboxHome
-	topologyDir := path.Join(sandboxHome, fmt.Sprintf("%s_multi_%d", providerName, basePort))
+	// Pull the registry of ports already in use by other dbdeployer
+	// sandboxes so we don't reuse them (issue #113).
+	installedPorts, _ := common.GetInstalledPorts(sandboxHome)
+	firstNodePort := basePort + 1
+	if freePort, err := common.FindFreePort(firstNodePort, installedPorts, 1); err == nil {
+		firstNodePort = freePort
+	}
+
+	topologyDir := path.Join(sandboxHome, fmt.Sprintf("%s_multi_%d", providerName, firstNodePort))
 	if common.DirExists(topologyDir) {
 		common.Exitf(1, "sandbox directory %s already exists", topologyDir)
 	}
@@ -73,13 +81,19 @@ func deployMultipleNonMySQL(cmd *cobra.Command, args []string, providerName stri
 	}
 
 	skipStart, _ := flags.GetBool(globals.SkipStartLabel)
+	nodePorts := make([]int, 0, nodes)
 
 	for i := 1; i <= nodes; i++ {
-		port := basePort + i
-		freePort, err := common.FindFreePort(port, []int{}, 1)
+		port := firstNodePort
+		if i > 1 {
+			port = nodePorts[i-2] + 1
+		}
+		freePort, err := common.FindFreePort(port, installedPorts, 1)
 		if err == nil {
 			port = freePort
 		}
+		installedPorts = append(installedPorts, port)
+		nodePorts = append(nodePorts, port)
 
 		nodeDir := path.Join(topologyDir, fmt.Sprintf("node%d", i))
 		config := providers.SandboxConfig{
@@ -102,6 +116,22 @@ func deployMultipleNonMySQL(cmd *cobra.Command, args []string, providerName stri
 		}
 
 		fmt.Printf("  Node %d deployed in %s (port: %d)\n", i, nodeDir, port)
+	}
+
+	// Write a top-level sandbox description so common.GetInstalledPorts()
+	// descends into the topology subdirs and sees per-node ports (issue #113).
+	home, _ := os.UserHomeDir()
+	basedir := path.Join(home, "opt", providerName, version)
+	topoDesc := common.SandboxDescription{
+		Basedir: basedir,
+		SBType:  globals.SbTypeMultiple,
+		Version: version,
+		Host:    "127.0.0.1",
+		Port:    nodePorts,
+		Nodes:   nodes,
+	}
+	if err := common.WriteSandboxDescription(topologyDir, topoDesc); err != nil {
+		fmt.Printf("WARNING: could not write topology sandbox description: %s\n", err)
 	}
 
 	fmt.Printf("%s multiple sandbox (%d nodes) deployed in %s\n", providerName, nodes, topologyDir)

--- a/cmd/replication.go
+++ b/cmd/replication.go
@@ -64,15 +64,22 @@ func deployReplicationNonMySQL(cmd *cobra.Command, args []string, providerName s
 	}
 
 	sandboxHome := defaults.Defaults().SandboxHome
-	topologyDir := path.Join(sandboxHome, fmt.Sprintf("%s_repl_%d", providerName, basePort))
+	// Pull the registry of ports already in use by other dbdeployer
+	// sandboxes so we don't reuse them (issue #113).
+	installedPorts, _ := common.GetInstalledPorts(sandboxHome)
+	primaryPort := basePort
+	if freePort, err := common.FindFreePort(basePort, installedPorts, 1); err == nil {
+		primaryPort = freePort
+	}
+	installedPorts = append(installedPorts, primaryPort)
+
+	topologyDir := path.Join(sandboxHome, fmt.Sprintf("%s_repl_%d", providerName, primaryPort))
 	if common.DirExists(topologyDir) {
 		common.Exitf(1, "sandbox directory %s already exists", topologyDir)
 	}
 	if err := os.MkdirAll(topologyDir, 0755); err != nil {
 		common.Exitf(1, "error creating topology directory %s: %s", topologyDir, err)
 	}
-
-	primaryPort := basePort
 
 	// Create and start primary with replication options
 	primaryDir := path.Join(topologyDir, "primary")
@@ -100,14 +107,16 @@ func deployReplicationNonMySQL(cmd *cobra.Command, args []string, providerName s
 
 	primaryInfo := providers.SandboxInfo{Dir: primaryDir, Port: primaryPort, Status: "running"}
 
-	// Create replicas sequentially
+	// Create replicas sequentially, accumulating each chosen port into
+	// installedPorts so the next replica skips past it.
 	var replicaPorts []int
 	for i := 1; i <= nodes-1; i++ {
 		replicaPort := primaryPort + i
-		freePort, err := common.FindFreePort(replicaPort, []int{}, 1)
+		freePort, err := common.FindFreePort(replicaPort, installedPorts, 1)
 		if err == nil {
 			replicaPort = freePort
 		}
+		installedPorts = append(installedPorts, replicaPort)
 
 		replicaDir := path.Join(topologyDir, fmt.Sprintf("replica%d", i))
 		replicaConfig := providers.SandboxConfig{
@@ -164,6 +173,20 @@ func deployReplicationNonMySQL(cmd *cobra.Command, args []string, providerName s
 		if err != nil {
 			common.Exitf(1, "ProxySQL deployment failed: %s", err)
 		}
+	}
+
+	// Write a top-level sandbox description so common.GetInstalledPorts()
+	// descends into the topology subdirs and sees per-node ports (issue #113).
+	topoDesc := common.SandboxDescription{
+		Basedir: basedir,
+		SBType:  globals.MasterSlaveLabel,
+		Version: version,
+		Host:    "127.0.0.1",
+		Port:    []int{primaryPort},
+		Nodes:   nodes,
+	}
+	if err := common.WriteSandboxDescription(topologyDir, topoDesc); err != nil {
+		fmt.Printf("WARNING: could not write topology sandbox description: %s\n", err)
 	}
 
 	fmt.Printf("%s replication sandbox (1 primary + %d replicas) deployed in %s\n",

--- a/providers/postgresql/replication.go
+++ b/providers/postgresql/replication.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/ProxySQL/dbdeployer/common"
+	"github.com/ProxySQL/dbdeployer/globals"
 	"github.com/ProxySQL/dbdeployer/providers"
 )
 
@@ -77,6 +79,23 @@ func (p *PostgreSQLProvider) CreateReplica(primary providers.SandboxInfo, config
 			os.RemoveAll(config.Dir)
 			return nil, fmt.Errorf("writing script %s: %w", name, err)
 		}
+	}
+
+	// Register the replica so common.GetInstalledPorts() can see its port
+	// (issue #113). Written before StartSandbox so the file is still on disk
+	// even if startup fails partway and we leave the dir behind for debugging.
+	sbDesc := common.SandboxDescription{
+		Basedir: basedir,
+		SBType:  globals.SbTypeSingle,
+		Version: config.Version,
+		Host:    config.Host,
+		Port:    []int{config.Port},
+		Nodes:   0,
+		LogFile: logFile,
+	}
+	if err := common.WriteSandboxDescription(config.Dir, sbDesc); err != nil {
+		os.RemoveAll(config.Dir)
+		return nil, fmt.Errorf("writing sandbox description: %w", err)
 	}
 
 	// Start the replica

--- a/providers/postgresql/sandbox.go
+++ b/providers/postgresql/sandbox.go
@@ -6,6 +6,8 @@ import (
 	"os/exec"
 	"path/filepath"
 
+	"github.com/ProxySQL/dbdeployer/common"
+	"github.com/ProxySQL/dbdeployer/globals"
 	"github.com/ProxySQL/dbdeployer/providers"
 )
 
@@ -78,6 +80,22 @@ func (p *PostgreSQLProvider) CreateSandbox(config providers.SandboxConfig) (*pro
 			os.RemoveAll(config.Dir)
 			return nil, fmt.Errorf("writing script %s: %w", name, err)
 		}
+	}
+
+	// Register the sandbox so common.GetInstalledPorts() can see its port
+	// and subsequent deploys allocate around it (issue #113).
+	sbDesc := common.SandboxDescription{
+		Basedir: basedir,
+		SBType:  globals.SbTypeSingle,
+		Version: config.Version,
+		Host:    config.Host,
+		Port:    []int{config.Port},
+		Nodes:   0,
+		LogFile: logFile,
+	}
+	if err := common.WriteSandboxDescription(config.Dir, sbDesc); err != nil {
+		os.RemoveAll(config.Dir)
+		return nil, fmt.Errorf("writing sandbox description: %w", err)
 	}
 
 	return &providers.SandboxInfo{


### PR DESCRIPTION
## Summary

Closes #113.

PostgreSQL deploys collided on the version-derived port (e.g. `16613` for 16.13) whenever more than one sandbox was deployed for the same version. The user's reproducer:

```bash
dbdeployer deploy single 16.13 --provider=postgresql        # picks 16613
dbdeployer deploy replication 16.13 --provider=postgresql   # also picks 16613 → bind fails
```

## Root cause (three layers, all contributing)

1. **Empty `installedPorts` slice.** All three PG deploy entry points (`deploy_postgresql.go`, `replication.go`, `multiple.go`) called `common.FindFreePort(port, []int{}, 1)`. `FindFreePort` only checks against the slice it's given — with an empty slice it returns the requested port unchanged, making the call a no-op.
2. **PG sandboxes never registered.** Even when a caller queried `common.GetInstalledPorts(sandboxHome)`, the registry walker only sees sandboxes that wrote `sbdescription.json`. PG provider didn't, so PG sandboxes were invisible.
3. **Topology dir named from `basePort`, not the chosen port.** `cmd/replication.go` and `cmd/multiple.go` built `<provider>_repl_<basePort>` / `<provider>_multi_<basePort>` — so even if `FindFreePort` had returned a different port, the topology dir was still named with the colliding one. Plus `replication.go` skipped FindFreePort for the primary entirely, and its replica loop didn't accumulate each just-chosen port before iterating.

## Fix

Match MySQL's behavior end-to-end:

- **`providers/postgresql/sandbox.go::CreateSandbox`** writes per-sandbox `sbdescription.json` so the sandbox is visible to `GetInstalledPorts`.
- **`providers/postgresql/replication.go::CreateReplica`** writes the same description for each replica (replicas don't go through `CreateSandbox`).
- **`cmd/deploy_postgresql.go`, `cmd/replication.go`, `cmd/multiple.go`** read `common.GetInstalledPorts(sandboxHome)` and feed the result to `FindFreePort`. The primary now goes through `FindFreePort` too. Replication and multiple loops accumulate each just-chosen port into `installedPorts` before allocating the next, so two replicas can't collide on the same port.
- **Topology dir names** now derive from the chosen port (post-`FindFreePort`), not `basePort`.
- **`cmd/replication.go` and `cmd/multiple.go`** write a top-level `sbdescription.json` at the topology dir with `Nodes: N` — the signal `GetInstalledPorts` uses to descend into per-node subdirs and pick up replica ports.

## Test plan

- [x] `go build ./...` clean.
- [x] `go test ./providers/postgresql/... ./cmd/... ./common/...` passes.
- [x] **Issue #113 reproducer end-to-end** (Ubuntu 24.04, tested locally against a temp merge with #117 since `dbdeployer unpack` needs that fix to produce a working extraction):

  ```
  deploy postgresql 16.13                  → pg_sandbox_16613         (16613)
  deploy replication 16.13 --provider=…    → postgresql_repl_16614    (16614/15/16)
  deploy multiple 16.13 --provider=… -n 3  → postgresql_multi_16617   (16617/18/19)
  ```

  All three deployed cleanly with no port collisions. `dbdeployer sandboxes` listed all three with the correct ports.

## Out of scope

The user asked for "act like MySQL". This PR matches that — same registry, same `FindFreePort` logic. Going further (an OS-level `net.Listen` probe to catch ports held by non-dbdeployer processes) would be a strictly broader fix and should be its own enhancement spanning all providers.

## Note on overlap with #117

This PR touches `providers/postgresql/sandbox.go` to add the `WriteSandboxDescription` call inside `CreateSandbox`; #117 adds the `checkLinuxLayout` guard near the top of the same function. The two changes are in different parts of the function and are mechanically separate. Whichever PR merges first, the other will need a trivial merge-conflict resolution in the `import` block and a small adjacency in `CreateSandbox`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved port allocation logic to prevent conflicts when deploying multiple sandboxes
  * Enhanced sandbox registration and tracking through persistent metadata storage

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ProxySQL/dbdeployer/pull/119)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->