### PR TITLE
fix(sandbox): retry rm -rf during delete to handle kill -9 file-handle race

### DIFF
--- a/sandbox/sandbox.go
+++ b/sandbox/sandbox.go
@@ -210,13 +210,11 @@ func checkDirectory(sandboxDef SandboxDef) (SandboxDef, error) {
 			if err != nil {
 				return sandboxDef, fmt.Errorf(globals.ErrWhileStoppingSandbox, sandboxDir)
 			}
-			_, err = common.RunCmdWithArgs("rm", []string{"-rf", sandboxDir})
-			if err != nil {
+			if err = removeDirWithRetry(sandboxDir); err != nil {
 				return sandboxDef, fmt.Errorf(globals.ErrWhileDeletingSandbox, sandboxDir)
 			}
 			if logDirectory != "" {
-				_, err = common.RunCmdWithArgs("rm", []string{"-rf", logDirectory})
-				if err != nil {
+				if err = removeDirWithRetry(logDirectory); err != nil {
 					return sandboxDef, fmt.Errorf("error while deleting log directory %s", logDirectory)
 				}
 			}
@@ -1183,6 +1181,30 @@ func getLogDirFromSbDescription(fullPath string) (string, error) {
 	return logDirectory, nil
 }
 
+// removeDirWithRetry runs `rm -rf <target>` with a short exponential backoff
+// retry loop. After the stop/send_kill script returns, the killed mysqld
+// process may not yet have finished releasing its open file descriptors —
+// during that brief window, last buffered writes can land in master/data/
+// after rm's readdir() walk, making the final rmdir(2) return ENOTEMPTY
+// ("Directory not empty"). Retrying handles that race (issue #121).
+// Total max wait: 200+400+800+1600+3200ms ≈ 6.2s.
+func removeDirWithRetry(target string) error {
+	backoff := 200 * time.Millisecond
+	var lastErr error
+	for attempt := 0; attempt < 5; attempt++ {
+		if attempt > 0 {
+			time.Sleep(backoff)
+			backoff *= 2
+		}
+		if _, err := common.RunCmdWithArgs("rm", []string{"-rf", target}); err == nil {
+			return nil
+		} else {
+			lastErr = err
+		}
+	}
+	return lastErr
+}
+
 // Deprecated: use RemoveCustomSandbox instead
 func RemoveSandbox(sandboxDir, sandbox string, runConcurrently bool) (execList []concurrent.ExecutionList, err error) {
 	fullPath := path.Join(sandboxDir, sandbox)
@@ -1273,8 +1295,7 @@ func RemoveSandbox(sandboxDir, sandbox string, runConcurrently bool) (execList [
 			if globals.UsingDbDeployer && target != logDirectory {
 				common.CondPrintf("Running %s\n", cmdStr)
 			}
-			_, err = common.RunCmdWithArgs("rm", rmArgs)
-			if err != nil {
+			if err = removeDirWithRetry(target); err != nil {
 				return emptyExecutionList, fmt.Errorf(globals.ErrWhileDeletingSandbox, target)
 			}
 			if globals.UsingDbDeployer && target != logDirectory {
@@ -1394,8 +1415,7 @@ func RemoveCustomSandbox(sandboxDir, sandbox string, runConcurrently, useStop bo
 			if globals.UsingDbDeployer && target != logDirectory {
 				common.CondPrintf("Running %s\n", cmdStr)
 			}
-			_, err = common.RunCmdWithArgs("rm", rmArgs)
-			if err != nil {
+			if err = removeDirWithRetry(target); err != nil {
 				return emptyExecutionList, fmt.Errorf(globals.ErrWhileDeletingSandbox, target)
 			}
 			if globals.UsingDbDeployer && target != logDirectory {


### PR DESCRIPTION
## Summary

Closes #121.

`RemoveSandbox`, `RemoveCustomSandbox`, and an earlier custom-delete path in `sandbox/sandbox.go` all do:

1. Run the sandbox's stop / `send_kill` script (the `destroy` mode of `send_kill` does `kill -9 $MYPID`).
2. Immediately `rm -rf` the sandbox directory.

`kill -9` doesn't synchronously wait for the killed process to release its open file descriptors. During that brief window, the dying mysqld's last buffered I/O can land inside `master/data/` *after* `rm`'s `readdir()` walk has already passed — making the final `rmdir(2)` return ENOTEMPTY:

```
rm: cannot remove '<sandbox>/master/data': Directory not empty
error while deleting sandbox <sandbox>
```

This is an intermittent flake but persistent enough to bite:

- master Integration Tests run `25839621095` failed on `MariaDB (10.11.9)`.
- PR #119 hit the same flake on **4 consecutive reruns** before clearing on the 5th.
- PR #114 hit it during initial review (cleared on first retry).

## Fix

Wrap the `rm -rf` in a small exponential-backoff retry loop (200ms + 400ms + 800ms + 1.6s + 3.2s ≈ 6.2s max wait). The race resolves in milliseconds in practice; retries handle it without changing the stop-script contract or templates across topologies.

A more thorough fix would be for `send_kill` to wait for the killed PIDs to disappear from `/proc` before returning, but that's a larger change touching templates for single/replication/multiple/tidb/etc. The localized retry in `RemoveSandbox` solves the user-visible symptom with one focused change.

## Files

`sandbox/sandbox.go` — adds a `removeDirWithRetry(target string) error` helper, then routes all four synchronous `rm -rf` call-sites through it:

- Early custom-delete path (around line 213) — both sandbox dir and log directory.
- The synchronous branch of `RemoveSandbox`.
- The synchronous branch of `RemoveCustomSandbox`.

The concurrent-mode branches that enqueue an `ExecCommand` into the parallel execution list are unchanged.

## Test plan

- [x] `go build ./...` clean.
- [x] `go test ./sandbox/...` — the three failures (`TestUseTemplate_MySQL`, `TestUseTemplate_MariaDB`, `TestReplicationStopAndUse_DelegateToSingleTemplates`) are pre-existing on master HEAD without my change. They require real MySQL binaries in `$SANDBOX_BINARY` to pass and are auto-skipped by `test/go-unit-tests.sh` in CI. Nothing related to the rm/delete code I touched.
- [ ] CI should run the full Integration Tests matrix; in particular `MariaDB (10.11.9)` is the most reliable repro of the race the new retry is supposed to handle.

## Note

The retry is bounded (max ~6s) and the per-attempt delay is short, so this doesn't measurably slow down healthy deletes — the rm normally succeeds on the first attempt and we never hit a sleep.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of sandbox directory cleanup by adding retry logic with exponential backoff to handle transient deletion failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ProxySQL/dbdeployer/pull/122)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->