### PR TITLE
feat(postgresql): add test_replication script for replication topology

### DIFF
--- a/cmd/replication.go
+++ b/cmd/replication.go
@@ -154,6 +154,17 @@ func deployReplicationNonMySQL(cmd *cobra.Command, args []string, providerName s
 		fmt.Printf("WARNING: could not write check_recovery script: %s\n", err)
 	}
 
+	testReplOpts := postgresql.ScriptOptions{
+		SandboxDir: topologyDir,
+		BinDir:     binDir,
+		LibDir:     libDir,
+		Port:       primaryPort,
+	}
+	testReplScript := postgresql.GenerateTestReplicationScript(testReplOpts, len(replicaPorts))
+	if err := os.WriteFile(path.Join(topologyDir, "test_replication"), []byte(testReplScript), 0755); err != nil { //nolint:gosec // scripts must be executable
+		fmt.Printf("WARNING: could not write test_replication script: %s\n", err)
+	}
+
 	// Handle --with-proxysql
 	withProxySQL, _ := flags.GetBool("with-proxysql")
 	if withProxySQL {

--- a/providers/postgresql/postgresql_test.go
+++ b/providers/postgresql/postgresql_test.go
@@ -127,6 +127,34 @@ func TestGenerateCheckRecoveryScript(t *testing.T) {
 	}
 }
 
+func TestGenerateTestReplicationScript(t *testing.T) {
+	script := GenerateTestReplicationScript(ScriptOptions{
+		SandboxDir: "/home/test/sandboxes/postgresql_repl_16614",
+		BinDir:     "/opt/postgresql/16.13/bin",
+		LibDir:     "/opt/postgresql/16.13/lib",
+		Port:       16614,
+	}, 2)
+	expectedSubstrings := []string{
+		`SBDIR=/home/test/sandboxes/postgresql_repl_16614`,
+		"./primary/use",
+		"pg_current_wal_lsn()",
+		"pg_last_wal_replay_lsn()",
+		"pg_is_in_recovery()",
+		"./replica1/use",
+		"./replica2/use",
+		"test_summary",
+	}
+	for _, want := range expectedSubstrings {
+		if !strings.Contains(script, want) {
+			t.Errorf("script missing %q", want)
+		}
+	}
+	// numReplicas=2 should NOT mention replica3
+	if strings.Contains(script, "./replica3/use") {
+		t.Error("script unexpectedly references replica3")
+	}
+}
+
 func TestGenerateScripts(t *testing.T) {
 	opts := ScriptOptions{
 		SandboxDir: "/tmp/pg_sandbox",

--- a/providers/postgresql/scripts.go
+++ b/providers/postgresql/scripts.go
@@ -60,3 +60,91 @@ func GenerateCheckRecoveryScript(opts ScriptOptions, replicaPorts []int) string 
 	}
 	return b.String()
 }
+
+// GenerateTestReplicationScript emits a topology-level test_replication
+// script that verifies replication is actually working: it creates a
+// table on the primary, inserts rows, captures the primary's WAL LSN,
+// then queries each replica to confirm the LSN matches and the row
+// count is in sync. Modeled on the MySQL `test_replication` template
+// (sandbox/templates/replication/test_replication.gotxt) but adapted to
+// PostgreSQL primitives (pg_current_wal_lsn / pg_last_wal_replay_lsn).
+//
+// numReplicas is the count of replica sub-sandboxes laid down by
+// `deploy replication --provider=postgresql` (i.e. one less than --nodes).
+// The generated script invokes ./primary/use and ./replicaN/use, which
+// the PostgreSQL provider already creates as per-sandbox `use` scripts.
+func GenerateTestReplicationScript(opts ScriptOptions, numReplicas int) string {
+	preamble := fmt.Sprintf(envPreamble, opts.LibDir)
+	var b strings.Builder
+	b.WriteString(preamble)
+	b.WriteString(fmt.Sprintf(`SBDIR=%s
+cd "$SBDIR"
+
+if [ ! -x ./primary/use ]; then
+    echo "# No primary found at ./primary/use"
+    exit 1
+fi
+PRIMARY=./primary/use
+
+FAILED=0
+PASSED=0
+
+function ok_equal {
+    fact="$1"
+    expected="$2"
+    msg="$3"
+    if [ "$fact" = "$expected" ]; then
+        echo "ok - (expected: <$expected>) - $msg"
+        PASSED=$((PASSED+1))
+    else
+        echo "not ok - (expected: <$expected> found: <$fact>) - $msg"
+        FAILED=$((FAILED+1))
+    fi
+}
+
+function test_summary {
+    TESTS=$((PASSED+FAILED))
+    printf "# Tests : %%5d\n" $TESTS
+    printf "# Passed: %%5d\n" $PASSED
+    printf "# Failed: %%5d\n" $FAILED
+    if [ "$FAILED" != "0" ]; then exit 1; fi
+    exit 0
+}
+
+YYYY_MM=$(date +%%Y-%%m)
+echo "# Creating and populating table on primary..."
+$PRIMARY -qc 'DROP TABLE IF EXISTS dbdeployer_test_replication'
+$PRIMARY -qc 'CREATE TABLE dbdeployer_test_replication (i INT NOT NULL PRIMARY KEY, msg VARCHAR(50), d DATE, t TIME, dt TIMESTAMP)'
+for N in $(seq -f '%%02.0f' 1 20); do
+    $PRIMARY -qc "INSERT INTO dbdeployer_test_replication VALUES ($N, 'test sandbox $N', '${YYYY_MM}-$N', '11:23:$N', '${YYYY_MM}-01 12:34:$N')"
+done
+
+PRIMARY_RECS=$($PRIMARY -Atqc 'SELECT count(*) FROM dbdeployer_test_replication')
+PRIMARY_LSN=$($PRIMARY -Atqc 'SELECT pg_current_wal_lsn()')
+echo "# Primary: rows=$PRIMARY_RECS  LSN=$PRIMARY_LSN"
+
+# Allow a brief window for streaming replication to catch up
+sleep 1
+
+`, opts.SandboxDir))
+
+	for n := 1; n <= numReplicas; n++ {
+		b.WriteString(fmt.Sprintf(`echo "# Testing replica %d"
+if [ -x ./replica%d/use ]; then
+    REPLICA_LSN=$(./replica%d/use -Atqc 'SELECT pg_last_wal_replay_lsn()')
+    REPLICA_RECS=$(./replica%d/use -Atqc 'SELECT count(*) FROM dbdeployer_test_replication')
+    REPLICA_IS_REPLICA=$(./replica%d/use -Atqc 'SELECT pg_is_in_recovery()')
+    ok_equal "$REPLICA_IS_REPLICA" "t" "replica %d is in recovery mode"
+    ok_equal "$REPLICA_LSN" "$PRIMARY_LSN" "replica %d LSN matches primary"
+    ok_equal "$REPLICA_RECS" "$PRIMARY_RECS" "replica %d row count matches primary"
+else
+    echo "not ok - replica %d/use not found"
+    FAILED=$((FAILED+1))
+fi
+
+`, n, n, n, n, n, n, n, n, n))
+	}
+
+	b.WriteString("test_summary\n")
+	return b.String()
+}


### PR DESCRIPTION
## Summary

Closes #120.

PostgreSQL replication deployments now get a `test_replication` script in the topology directory, alongside the existing `check_replication` and `check_recovery`. Mirrors the MySQL `test_replication` template but uses PostgreSQL primitives.

## What it does

When you run it from the topology dir (`postgresql_repl_<port>/`):

1. Creates a test table `dbdeployer_test_replication` on the primary.
2. Inserts 20 rows.
3. Captures the primary's `pg_current_wal_lsn()` and row count.
4. Briefly sleeps to give streaming replication a moment to catch up.
5. For each replica: asserts `pg_is_in_recovery()` = `t`, `pg_last_wal_replay_lsn()` matches the primary's LSN, and `count(*)` matches.
6. Reports tap-style `ok` / `not ok` per assertion; exits 1 on any failure.

## Files

- **`providers/postgresql/scripts.go`** — new `GenerateTestReplicationScript(opts, numReplicas)` function. Embeds an `ok_equal` / `test_summary` helper pair (same shape as the MySQL template).
- **`cmd/replication.go`** — generates `test_replication` next to the existing `check_replication` / `check_recovery` writes in `deployReplicationNonMySQL`.
- **`providers/postgresql/postgresql_test.go`** — `TestGenerateTestReplicationScript` covers expected substrings and bound checks on `numReplicas` (no replica3 references for a 2-replica deploy).

## Reference

Sample script in the issue body was provided by Ronald Bradford (issue author). Implementation follows it closely, adapted to the actual PG provider's per-sandbox `use` script layout (`./primary/use`, `./replicaN/use`) rather than the MySQL-style `./m` / `./n1` shortcuts that the PG topology doesn't create.

## Test plan

- [x] `go build ./...` clean.
- [x] `go test ./providers/postgresql/...` — `TestGenerateTestReplicationScript` and existing tests pass.
- [x] Generated script `bash -n` syntax-checks cleanly.
- [x] Visually inspected the generated output for a 2-replica deploy — each replica section properly numbered, sandbox dir interpolated, LSN/recovery/row-count assertions all present.

## Note on timing flakiness

PostgreSQL streaming replication is asynchronous; a one-second sleep between primary writes and replica reads is typically enough but can flake on a busy system. The Ronald-provided reference uses `sleep 0.5` and the same approach. A more robust variant would poll-with-timeout for the replica's LSN to match the primary's — happy to fold that in as a follow-up if this turns out flaky in practice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PostgreSQL replication topologies now automatically generate a test script that validates streaming replication health by verifying each replica's recovery status, WAL LSN synchronization with the primary, and data consistency.

* **Tests**
  * Added comprehensive test coverage for the replication validation script generator.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ProxySQL/dbdeployer/pull/123)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->