### PR TITLE
Fix ports/scripts/sandbox-directory for PostgreSQL+ProxySQL

### DIFF
--- a/cmd/replication.go
+++ b/cmd/replication.go
@@ -73,9 +73,34 @@ func deployReplicationNonMySQL(cmd *cobra.Command, args []string, providerName s
 	}
 	installedPorts = append(installedPorts, primaryPort)
 
-	topologyDir := path.Join(sandboxHome, fmt.Sprintf("%s_repl_%d", providerName, primaryPort))
+	sandboxDirName, _ := flags.GetString(globals.SandboxDirectoryLabel)
+	force, _ := flags.GetBool(globals.ForceLabel)
+
+	var topologyDir string
+	if sandboxDirName != "" {
+		topologyDir = path.Join(sandboxHome, sandboxDirName)
+	} else {
+		topologyDir = path.Join(sandboxHome, fmt.Sprintf("%s_repl_%d", providerName, primaryPort))
+	}
+
 	if common.DirExists(topologyDir) {
-		common.Exitf(1, "sandbox directory %s already exists", topologyDir)
+		if !force {
+			common.Exitf(1, "sandbox directory %s already exists", topologyDir)
+		}
+		common.CondPrintf("Overwriting directory %s\n", topologyDir)
+		entries, err := os.ReadDir(topologyDir)
+		if err == nil {
+			for _, entry := range entries {
+				if !entry.IsDir() {
+					continue
+				}
+				stopScript := path.Join(topologyDir, entry.Name(), "stop")
+				if common.ExecExists(stopScript) {
+					_, _ = common.RunCmd(stopScript)
+				}
+			}
+		}
+		common.RmdirAll(topologyDir)
 	}
 	if err := os.MkdirAll(topologyDir, 0755); err != nil {
 		common.Exitf(1, "error creating topology directory %s: %s", topologyDir, err)

--- a/providers/postgresql/postgresql.go
+++ b/providers/postgresql/postgresql.go
@@ -41,6 +41,15 @@ func (p *PostgreSQLProvider) DefaultPorts() providers.PortRange {
 	return providers.PortRange{BasePort: 15000, PortsPerInstance: 1}
 }
 
+const proxySQLPortBase = 4518
+
+// ProxySQLAdminPort returns the default ProxySQL admin port for a PostgreSQL
+// sandbox primary. It mirrors VersionToPort in the 4518+ range so ProxySQL
+// does not reuse the MySQL-default 6032 ports.
+func ProxySQLAdminPort(primaryPort int) int {
+	return primaryPort - (15000 - proxySQLPortBase)
+}
+
 func (p *PostgreSQLProvider) SupportedTopologies() []string {
 	return []string{"single", "multiple", "replication"}
 }

--- a/providers/postgresql/postgresql_test.go
+++ b/providers/postgresql/postgresql_test.go
@@ -62,6 +62,26 @@ func TestPostgreSQLProviderSupportedTopologies(t *testing.T) {
 	}
 }
 
+func TestPostgreSQLProxySQLAdminPort(t *testing.T) {
+	tests := []struct {
+		version  string
+		expected int
+	}{
+		{"16.14", 6132},
+		{"16.13", 6131},
+		{"16.3", 6121},
+	}
+	for _, tt := range tests {
+		primaryPort, err := VersionToPort(tt.version)
+		if err != nil {
+			t.Fatalf("VersionToPort(%q): %v", tt.version, err)
+		}
+		if got := ProxySQLAdminPort(primaryPort); got != tt.expected {
+			t.Errorf("ProxySQLAdminPort(%q) = %d, want %d", tt.version, got, tt.expected)
+		}
+	}
+}
+
 func TestPostgreSQLVersionToPort(t *testing.T) {
 	tests := []struct {
 		version  string

--- a/providers/proxysql/config.go
+++ b/providers/proxysql/config.go
@@ -31,12 +31,16 @@ func GenerateConfig(cfg ProxySQLConfig) string {
 
 	b.WriteString(fmt.Sprintf("datadir=\"%s\"\n\n", cfg.DataDir))
 
+	isPgsql := cfg.BackendProvider == "postgresql"
+
 	b.WriteString("admin_variables=\n{\n")
 	b.WriteString(fmt.Sprintf("    admin_credentials=\"%s:%s\"\n", cfg.AdminUser, cfg.AdminPassword))
-	b.WriteString(fmt.Sprintf("    mysql_ifaces=\"%s:%d\"\n", cfg.AdminHost, cfg.AdminPort))
+	if isPgsql {
+		b.WriteString(fmt.Sprintf("    pgsql_ifaces=\"%s:%d\"\n", cfg.AdminHost, cfg.AdminPort))
+	} else {
+		b.WriteString(fmt.Sprintf("    mysql_ifaces=\"%s:%d\"\n", cfg.AdminHost, cfg.AdminPort))
+	}
 	b.WriteString("}\n\n")
-
-	isPgsql := cfg.BackendProvider == "postgresql"
 
 	if isPgsql {
 		b.WriteString("pgsql_variables=\n{\n")

--- a/providers/proxysql/config_test.go
+++ b/providers/proxysql/config_test.go
@@ -115,6 +115,12 @@ func TestGenerateConfigPostgreSQL(t *testing.T) {
 	if !strings.Contains(config, "pgsql_variables") {
 		t.Error("expected pgsql_variables block")
 	}
+	if !strings.Contains(config, `pgsql_ifaces="127.0.0.1:6032"`) {
+		t.Error("expected pgsql_ifaces for postgresql backend")
+	}
+	if strings.Contains(config, "mysql_ifaces") {
+		t.Error("should not contain mysql_ifaces for postgresql backend")
+	}
 	if strings.Contains(config, "mysql_servers") {
 		t.Error("should not contain mysql_servers for postgresql backend")
 	}

--- a/providers/proxysql/proxysql.go
+++ b/providers/proxysql/proxysql.go
@@ -112,11 +112,11 @@ func (p *ProxySQLProvider) CreateSandbox(config providers.SandboxConfig) (*provi
 			pidFile),
 	}
 	if config.Options["backend_provider"] == "postgresql" {
-		psqlURI := func(port int) string {
-			return fmt.Sprintf("postgresql://%s:%s@%s:%d", monitorUser, monitorPass, host, port)
+		psqlURI := func(user, password string, port int) string {
+			return fmt.Sprintf("postgresql://%s:%s@%s:%d", user, password, host, port)
 		}
-		scripts["use"] = fmt.Sprintf("#!/bin/bash\npsql %s \"$@\"\n", psqlURI(adminPort))
-		scripts["use_proxy"] = fmt.Sprintf("#!/bin/bash\npsql %s \"$@\"\n", psqlURI(mysqlPort))
+		scripts["use"] = fmt.Sprintf("#!/bin/bash\npsql %s \"$@\"\n", psqlURI(adminUser, adminPassword, adminPort))
+		scripts["use_proxy"] = fmt.Sprintf("#!/bin/bash\npsql %s \"$@\"\n", psqlURI(monitorUser, monitorPass, mysqlPort))
 	} else {
 		scripts["use"] = fmt.Sprintf("#!/bin/bash\nmysql -h %s -P %d -u %s -p%s --prompt 'ProxySQL Admin> ' \"$@\"\n",
 			host, adminPort, adminUser, adminPassword)

--- a/providers/proxysql/proxysql.go
+++ b/providers/proxysql/proxysql.go
@@ -110,13 +110,16 @@ func (p *ProxySQLProvider) CreateSandbox(config providers.SandboxConfig) (*provi
 			pidFile, cfgPath),
 		"status": fmt.Sprintf("#!/bin/bash\nPIDFILE=%s\nif [ -f $PIDFILE ] && kill -0 $(cat $PIDFILE) 2>/dev/null; then\n  echo \"ProxySQL running (pid $(cat $PIDFILE))\"\nelse\n  echo 'ProxySQL not running'\n  exit 1\nfi\n",
 			pidFile),
-		"use": fmt.Sprintf("#!/bin/bash\nmysql -h %s -P %d -u %s -p%s --prompt 'ProxySQL Admin> ' \"$@\"\n",
-			host, adminPort, adminUser, adminPassword),
 	}
 	if config.Options["backend_provider"] == "postgresql" {
-		scripts["use_proxy"] = fmt.Sprintf("#!/bin/bash\npsql -h %s -p %d -U %s \"$@\"\n",
-			host, mysqlPort, monitorUser)
+		psqlURI := func(port int) string {
+			return fmt.Sprintf("postgresql://%s:%s@%s:%d", monitorUser, monitorPass, host, port)
+		}
+		scripts["use"] = fmt.Sprintf("#!/bin/bash\npsql %s \"$@\"\n", psqlURI(adminPort))
+		scripts["use_proxy"] = fmt.Sprintf("#!/bin/bash\npsql %s \"$@\"\n", psqlURI(mysqlPort))
 	} else {
+		scripts["use"] = fmt.Sprintf("#!/bin/bash\nmysql -h %s -P %d -u %s -p%s --prompt 'ProxySQL Admin> ' \"$@\"\n",
+			host, adminPort, adminUser, adminPassword)
 		// use_proxy connects as msandbox (app user), not the monitor user (rsandbox)
 		scripts["use_proxy"] = fmt.Sprintf("#!/bin/bash\nmysql -h %s -P %d -u msandbox -pmsandbox --prompt 'ProxySQL> ' \"$@\"\n",
 			host, mysqlPort)

--- a/sandbox/proxysql_topology.go
+++ b/sandbox/proxysql_topology.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/ProxySQL/dbdeployer/common"
 	"github.com/ProxySQL/dbdeployer/providers"
+	"github.com/ProxySQL/dbdeployer/providers/postgresql"
 )
 
 // DeployProxySQLForTopology creates a ProxySQL sandbox configured for a MySQL topology.
@@ -60,10 +61,16 @@ func DeployProxySQLForTopology(sandboxDir string, masterPort int, slavePorts []i
 	proxysqlDir := path.Join(sandboxDir, "proxysql")
 
 	if proxysqlPort == 0 {
-		proxysqlPort = 6032
+		if backendProvider == postgresql.ProviderName {
+			proxysqlPort = postgresql.ProxySQLAdminPort(masterPort)
+		} else {
+			proxysqlPort = 6032
+		}
 	}
-	// Find 2 consecutive free ports (admin + mysql) to avoid TIME_WAIT conflicts
-	freePort, err := common.FindFreePort(proxysqlPort, []int{}, 2)
+	installedPorts := []int{masterPort}
+	installedPorts = append(installedPorts, slavePorts...)
+	// Find 2 consecutive free ports (admin + proxy) to avoid TIME_WAIT conflicts
+	freePort, err := common.FindFreePort(proxysqlPort, installedPorts, 2)
 	if err == nil {
 		proxysqlPort = freePort
 	}


### PR DESCRIPTION
--sandbox-directory was not working with --provider=postgresql
- Fix ProxySQL ports with PostgreSQL (enable flexible ports)
- Updated proxysql.cnf
- Updated use/use_proxy


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ProxySQL now fully supports PostgreSQL backends with automatic admin-port assignment and provider-aware lifecycle scripts.
  * Replication topology deployment respects the `--sandbox-directory` flag for custom storage locations.

* **Bug Fixes**
  * ProxySQL config generation now emits correct interface settings for PostgreSQL vs MySQL.
  * Improved handling of existing topology directories: `--force` stops existing sandboxes and cleans up before recreation; port selection avoids conflicts.

* **Tests**
  * Added tests for ProxySQL admin port calculation with PostgreSQL backends.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ProxySQL/dbdeployer/pull/125?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->