### PR TITLE
Fix install workflow repository context

### DIFF
--- a/.github/workflows/install_script_test.yml
+++ b/.github/workflows/install_script_test.yml
@@ -42,7 +42,7 @@ jobs:
           which dbdeployer
           dbdeployer --version
           INSTALLED_VERSION=$(dbdeployer --version | awk '{print $NF}')
-          EXPECTED_VERSION=$(gh release view --json tagName --jq '.tagName' | sed 's/^v//')
+          EXPECTED_VERSION=$(gh release view --repo ProxySQL/dbdeployer --json tagName --jq '.tagName' | sed 's/^v//')
           echo "Installed: $INSTALLED_VERSION"
           echo "Expected:  $EXPECTED_VERSION"
           [ "$INSTALLED_VERSION" = "$EXPECTED_VERSION" ] || {


### PR DESCRIPTION
## Summary

- Pin the install-test workflow's `gh release view` command to `ProxySQL/dbdeployer`.
- Prevent the version verification step from failing in its checkout-less runner.

## Root cause

The workflow runs without `actions/checkout`, so GitHub CLI has no local repository context. The unqualified `gh release view` command therefore failed before comparing the installed version.

## Validation

- Verified the previously failing command from a directory without Git metadata.
- Verified `gh release view --repo ProxySQL/dbdeployer --json tagName --jq '.tagName'` succeeds and returns `v2.3.0`.
- Parsed `.github/workflows/install_script_test.yml` successfully.
- `git diff --check` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installation verification by checking the installed version against the published release version.
  * Retained clear version reporting and failure detection when the versions do not match.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->