### PR TITLE
fix(postgres): honor --sandbox-home/--port/--sandbox-directory/--db-user/--db-password in deploy postgresql

### DIFF
--- a/cmd/deploy_postgresql.go
+++ b/cmd/deploy_postgresql.go
@@ -20,7 +20,7 @@ import (
 	"path"
 
 	"github.com/ProxySQL/dbdeployer/common"
-	"github.com/ProxySQL/dbdeployer/defaults"
+	"github.com/ProxySQL/dbdeployer/globals"
 	"github.com/ProxySQL/dbdeployer/providers"
 	"github.com/ProxySQL/dbdeployer/providers/postgresql"
 	"github.com/spf13/cobra"
@@ -44,22 +44,51 @@ func deploySandboxPostgreSQL(cmd *cobra.Command, args []string) {
 		common.Exitf(1, "PostgreSQL binaries not found: %s\nRun: dbdeployer unpack --provider=postgresql <server.deb> <client.deb>", err)
 	}
 
-	port, err := postgresql.VersionToPort(version)
+	// sandbox-home: honor --sandbox-home. The flag is registered on the root
+	// command with defaults.Defaults().SandboxHome as its default, so reading it
+	// directly already falls back to the configured default when not provided.
+	sandboxHome, err := getAbsolutePathFromFlag(cmd, globals.SandboxHomeLabel)
 	if err != nil {
-		common.Exitf(1, "error computing port: %s", err)
+		common.Exitf(1, "error defining absolute path for --%s: %s", globals.SandboxHomeLabel, err)
 	}
 
-	sandboxHome := defaults.Defaults().SandboxHome
-	installedPorts, _ := common.GetInstalledPorts(sandboxHome)
-	freePort, portErr := common.FindFreePort(port, installedPorts, 1)
-	if portErr == nil {
-		port = freePort
+	// port: honor --port; if not provided (<=0), compute it from the version and
+	// pick the next free port, matching the previous behavior.
+	port, _ := flags.GetInt(globals.PortLabel)
+	if port <= 0 {
+		port, err = postgresql.VersionToPort(version)
+		if err != nil {
+			common.Exitf(1, "error computing port: %s", err)
+		}
+		installedPorts, _ := common.GetInstalledPorts(sandboxHome)
+		freePort, portErr := common.FindFreePort(port, installedPorts, 1)
+		if portErr == nil {
+			port = freePort
+		}
 	}
 
-	sandboxDir := path.Join(sandboxHome, fmt.Sprintf("pg_sandbox_%d", port))
+	// sandbox-directory: honor --sandbox-directory; fall back to pg_sandbox_<port>.
+	sandboxDirectory, _ := flags.GetString(globals.SandboxDirectoryLabel)
+	if sandboxDirectory == "" {
+		sandboxDirectory = fmt.Sprintf("pg_sandbox_%d", port)
+	}
+	sandboxDir := path.Join(sandboxHome, sandboxDirectory)
 
 	if common.DirExists(sandboxDir) {
 		common.Exitf(1, "sandbox directory %s already exists", sandboxDir)
+	}
+
+	// db-user / db-password: these flags are registered on "deploy" with the
+	// MySQL default ("msandbox"). To preserve the PostgreSQL default
+	// ("postgres" / "") when they are not explicitly provided, only honor them
+	// when changed on the command line.
+	dbUser := "postgres"
+	if flags.Changed(globals.DbUserLabel) {
+		dbUser, _ = flags.GetString(globals.DbUserLabel)
+	}
+	dbPassword := ""
+	if flags.Changed(globals.DbPasswordLabel) {
+		dbPassword, _ = flags.GetString(globals.DbPasswordLabel)
 	}
 
 	config := providers.SandboxConfig{
@@ -67,8 +96,8 @@ func deploySandboxPostgreSQL(cmd *cobra.Command, args []string) {
 		Dir:        sandboxDir,
 		Port:       port,
 		Host:       "127.0.0.1",
-		DbUser:     "postgres",
-		DbPassword: "",
+		DbUser:     dbUser,
+		DbPassword: dbPassword,
 		Options:    map[string]string{},
 	}
 

--- a/cmd/deploy_postgresql.go
+++ b/cmd/deploy_postgresql.go
@@ -40,7 +40,26 @@ func deploySandboxPostgreSQL(cmd *cobra.Command, args []string) {
 		common.Exitf(1, "invalid version: %s", err)
 	}
 
-	if _, err := p.FindBinary(version); err != nil {
+	// Binary discovery. The --sandbox-binary flag is shared with the MySQL
+	// path and defaults to ~/opt/mysql, so it is only applied to PostgreSQL
+	// when explicitly provided. When set, binaries are expected at
+	// <sandbox-binary>/<version>/bin/postgres and that directory becomes the
+	// sandbox basedir (bin/lib/share). When not set, fall back to the strict
+	// historical behavior: ~/opt/postgresql/<version>.
+	options := map[string]string{}
+	if flags.Changed(globals.SandboxBinaryLabel) {
+		sandboxBinary, _ := flags.GetString(globals.SandboxBinaryLabel)
+		sbAbs, err := common.AbsolutePath(sandboxBinary)
+		if err != nil {
+			common.Exitf(1, "error defining absolute path for --%s: %s", globals.SandboxBinaryLabel, err)
+		}
+		basedir := path.Join(sbAbs, version)
+		binPath := path.Join(basedir, "bin", "postgres")
+		if !common.FileExists(binPath) {
+			common.Exitf(1, "PostgreSQL binary not found at %s", binPath)
+		}
+		options["basedir"] = basedir
+	} else if _, err := p.FindBinary(version); err != nil {
 		common.Exitf(1, "PostgreSQL binaries not found: %s\nRun: dbdeployer unpack --provider=postgresql <server.deb> <client.deb>", err)
 	}
 
@@ -98,7 +117,7 @@ func deploySandboxPostgreSQL(cmd *cobra.Command, args []string) {
 		Host:       "127.0.0.1",
 		DbUser:     dbUser,
 		DbPassword: dbPassword,
-		Options:    map[string]string{},
+		Options:    options,
 	}
 
 	if _, err := p.CreateSandbox(config); err != nil {

--- a/providers/postgresql/postgresql_test.go
+++ b/providers/postgresql/postgresql_test.go
@@ -212,3 +212,48 @@ func TestGenerateScripts(t *testing.T) {
 		t.Error("use script missing port")
 	}
 }
+
+// TestGenerateScriptsDbUserPropagation ensures the configured db-user is embedded
+// in the generated psql/initdb invocations, and that an empty DbUser falls back
+// to the historical "postgres" default.
+func TestGenerateScriptsDbUserPropagation(t *testing.T) {
+	// Explicit user: scripts must reference it and not the default.
+	custom := GenerateScripts(ScriptOptions{
+		BinDir:  "/opt/postgresql/16.13/bin",
+		DataDir: "/tmp/pg/data",
+		Port:    16613,
+		DbUser:  "wse",
+	})
+	if !strings.Contains(custom["use"], "-U wse") {
+		t.Errorf("use script must embed -U wse; got: %q", custom["use"])
+	}
+	if strings.Contains(custom["use"], "-U postgres") {
+		t.Errorf("use script must not reference -U postgres; got: %q", custom["use"])
+	}
+	if !strings.Contains(custom["clear"], "--username=wse") {
+		t.Errorf("clear script must embed --username=wse; got: %q", custom["clear"])
+	}
+
+	// Empty user: falls back to "postgres" (backward compatible).
+	def := GenerateScripts(ScriptOptions{
+		BinDir:  "/opt/postgresql/16.13/bin",
+		DataDir: "/tmp/pg/data",
+		Port:    16613,
+	})
+	if !strings.Contains(def["use"], "-U postgres") {
+		t.Errorf("default use script must embed -U postgres; got: %q", def["use"])
+	}
+	if !strings.Contains(def["clear"], "--username=postgres") {
+		t.Errorf("default clear script must embed --username=postgres; got: %q", def["clear"])
+	}
+
+	// Replication scripts honor DbUser too.
+	repl := GenerateCheckReplicationScript(ScriptOptions{
+		BinDir: "/opt/postgresql/16.13/bin",
+		Port:   16613,
+		DbUser: "wse",
+	})
+	if !strings.Contains(repl, "-U wse") {
+		t.Errorf("replication script must embed -U wse; got: %q", repl)
+	}
+}

--- a/providers/postgresql/postgresql_test.go
+++ b/providers/postgresql/postgresql_test.go
@@ -1,6 +1,8 @@
 package postgresql
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -276,5 +278,35 @@ func TestGenerateCheckRecoveryScriptDbUser(t *testing.T) {
 	}
 	if !strings.Contains(script, "16614") || !strings.Contains(script, "16615") {
 		t.Error("recovery script missing replica ports")
+	}
+}
+
+// TestResolveBasedir locks in the contract that deploy_postgresql.go relies on:
+// an explicit Options["basedir"] override (set when --sandbox-binary is given)
+// is honored as-is, and absent/empty values fall back to ~/opt/postgresql/<ver>.
+func TestResolveBasedir(t *testing.T) {
+	p := NewPostgreSQLProvider()
+	home, _ := os.UserHomeDir()
+	wantDefault := filepath.Join(home, "opt", "postgresql", "18.4")
+
+	// Explicit override is returned verbatim.
+	got, err := p.resolveBasedir(providers.SandboxConfig{
+		Version: "18.4",
+		Options: map[string]string{"basedir": "/custom/root/18.4"},
+	})
+	if err != nil || got != "/custom/root/18.4" {
+		t.Errorf("override: got (%q, %v), want /custom/root/18.4", got, err)
+	}
+
+	// No Options: falls back to ~/opt/postgresql/<version>.
+	got, err = p.resolveBasedir(providers.SandboxConfig{Version: "18.4", Options: map[string]string{}})
+	if err != nil || got != wantDefault {
+		t.Errorf("fallback: got (%q, %v), want %q", got, err, wantDefault)
+	}
+
+	// Empty basedir value is treated as unset (falls back).
+	got, err = p.resolveBasedir(providers.SandboxConfig{Version: "18.4", Options: map[string]string{"basedir": ""}})
+	if err != nil || got != wantDefault {
+		t.Errorf("empty basedir: got (%q, %v), want %q", got, err, wantDefault)
 	}
 }

--- a/providers/postgresql/postgresql_test.go
+++ b/providers/postgresql/postgresql_test.go
@@ -214,24 +214,24 @@ func TestGenerateScripts(t *testing.T) {
 }
 
 // TestGenerateScriptsDbUserPropagation ensures the configured db-user is embedded
-// in the generated psql/initdb invocations, and that an empty DbUser falls back
-// to the historical "postgres" default.
+// (shell-quoted) in the generated psql/initdb invocations, and that an empty
+// DbUser falls back to the historical "postgres" default.
 func TestGenerateScriptsDbUserPropagation(t *testing.T) {
-	// Explicit user: scripts must reference it and not the default.
+	// Explicit user: scripts must reference it (shell-quoted) and not the default.
 	custom := GenerateScripts(ScriptOptions{
 		BinDir:  "/opt/postgresql/16.13/bin",
 		DataDir: "/tmp/pg/data",
 		Port:    16613,
-		DbUser:  "wse",
+		DbUser:  "testuser",
 	})
-	if !strings.Contains(custom["use"], "-U wse") {
-		t.Errorf("use script must embed -U wse; got: %q", custom["use"])
+	if !strings.Contains(custom["use"], "-U 'testuser'") {
+		t.Errorf("use script must embed -U 'testuser'; got: %q", custom["use"])
 	}
 	if strings.Contains(custom["use"], "-U postgres") {
 		t.Errorf("use script must not reference -U postgres; got: %q", custom["use"])
 	}
-	if !strings.Contains(custom["clear"], "--username=wse") {
-		t.Errorf("clear script must embed --username=wse; got: %q", custom["clear"])
+	if !strings.Contains(custom["clear"], "--username='testuser'") {
+		t.Errorf("clear script must embed --username='testuser'; got: %q", custom["clear"])
 	}
 
 	// Empty user: falls back to "postgres" (backward compatible).
@@ -240,20 +240,41 @@ func TestGenerateScriptsDbUserPropagation(t *testing.T) {
 		DataDir: "/tmp/pg/data",
 		Port:    16613,
 	})
-	if !strings.Contains(def["use"], "-U postgres") {
-		t.Errorf("default use script must embed -U postgres; got: %q", def["use"])
+	if !strings.Contains(def["use"], "-U 'postgres'") {
+		t.Errorf("default use script must embed -U 'postgres'; got: %q", def["use"])
 	}
-	if !strings.Contains(def["clear"], "--username=postgres") {
-		t.Errorf("default clear script must embed --username=postgres; got: %q", def["clear"])
+	if !strings.Contains(def["clear"], "--username='postgres'") {
+		t.Errorf("default clear script must embed --username='postgres'; got: %q", def["clear"])
 	}
 
 	// Replication scripts honor DbUser too.
 	repl := GenerateCheckReplicationScript(ScriptOptions{
 		BinDir: "/opt/postgresql/16.13/bin",
 		Port:   16613,
-		DbUser: "wse",
+		DbUser: "testuser",
 	})
-	if !strings.Contains(repl, "-U wse") {
-		t.Errorf("replication script must embed -U wse; got: %q", repl)
+	if !strings.Contains(repl, "-U 'testuser'") {
+		t.Errorf("replication script must embed -U 'testuser'; got: %q", repl)
+	}
+}
+
+// TestGenerateCheckRecoveryScriptDbUser ensures the recovery-check script embeds
+// the configured db-user (shell-quoted), complementing the existing
+// TestGenerateCheckRecoveryScript which only checks the query text and ports.
+func TestGenerateCheckRecoveryScriptDbUser(t *testing.T) {
+	ports := []int{16614, 16615}
+	script := GenerateCheckRecoveryScript(ScriptOptions{
+		BinDir: "/opt/postgresql/16.13/bin",
+		Port:   16613,
+		DbUser: "testuser",
+	}, ports)
+	if !strings.Contains(script, "pg_is_in_recovery") {
+		t.Error("missing pg_is_in_recovery query")
+	}
+	if !strings.Contains(script, "-U 'testuser'") {
+		t.Errorf("recovery script must embed -U 'testuser'; got: %q", script)
+	}
+	if !strings.Contains(script, "16614") || !strings.Contains(script, "16615") {
+		t.Error("recovery script missing replica ports")
 	}
 }

--- a/providers/postgresql/replication.go
+++ b/providers/postgresql/replication.go
@@ -72,6 +72,7 @@ func (p *PostgreSQLProvider) CreateReplica(primary providers.SandboxInfo, config
 		LibDir:     libDir,
 		Port:       config.Port,
 		LogFile:    logFile,
+		DbUser:     config.DbUser,
 	})
 	for name, content := range scripts {
 		scriptPath := filepath.Join(config.Dir, name)

--- a/providers/postgresql/replication.go
+++ b/providers/postgresql/replication.go
@@ -22,12 +22,20 @@ func (p *PostgreSQLProvider) CreateReplica(primary providers.SandboxInfo, config
 	dataDir := filepath.Join(config.Dir, "data")
 	logFile := filepath.Join(config.Dir, "postgresql.log")
 
+	// The replica connects to the primary as the configured superuser, which
+	// matches the role created by initdb --username=<db-user>. Fall back to
+	// "postgres" to preserve the historical behavior when no user is set.
+	dbUser := config.DbUser
+	if dbUser == "" {
+		dbUser = "postgres"
+	}
+
 	// pg_basebackup from the running primary
 	pgBasebackup := filepath.Join(binDir, "pg_basebackup")
 	bbCmd := exec.Command(pgBasebackup,
 		"-h", "127.0.0.1",
 		"-p", fmt.Sprintf("%d", primary.Port),
-		"-U", "postgres",
+		"-U", dbUser,
 		"-D", dataDir,
 		"-Fp", "-Xs", "-R",
 	)

--- a/providers/postgresql/sandbox.go
+++ b/providers/postgresql/sandbox.go
@@ -35,11 +35,45 @@ func (p *PostgreSQLProvider) CreateSandbox(config providers.SandboxConfig) (*pro
 	// won't match our extracted layout at ~/opt/postgresql/<version>/share/.
 	shareDir := filepath.Join(basedir, "share")
 	initdbPath := filepath.Join(binDir, "initdb")
-	initCmd := exec.Command(initdbPath, "-D", dataDir, "--auth=trust", "--username=postgres", "-L", shareDir)
+	// The initial PostgreSQL superuser is the sandbox db-user (defaults to
+	// "postgres" via the deploy layer). When a password is provided, it is set
+	// on this superuser through a temporary pwfile so the credential does not
+	// leak through the process list. The sandbox keeps trust auth
+	// (GeneratePgHbaConf), so the password is stored but not enforced unless
+	// pg_hba.conf is tightened.
+	initArgs := []string{"-D", dataDir, "--auth=trust", "--username=" + config.DbUser, "-L", shareDir}
+	var pwFile string
+	if config.DbPassword != "" {
+		tmp, err := os.CreateTemp("", "dbdeployer-pg-pw-*")
+		if err != nil {
+			os.RemoveAll(config.Dir)
+			return nil, fmt.Errorf("creating password file: %w", err)
+		}
+		if _, err := tmp.WriteString(config.DbPassword); err != nil {
+			tmp.Close()
+			os.Remove(tmp.Name())
+			os.RemoveAll(config.Dir)
+			return nil, fmt.Errorf("writing password file: %w", err)
+		}
+		if err := tmp.Close(); err != nil {
+			os.Remove(tmp.Name())
+			os.RemoveAll(config.Dir)
+			return nil, fmt.Errorf("closing password file: %w", err)
+		}
+		pwFile = tmp.Name()
+		initArgs = append(initArgs, "--pwfile="+pwFile)
+	}
+	initCmd := exec.Command(initdbPath, initArgs...)
 	initCmd.Env = append(os.Environ(), fmt.Sprintf("LD_LIBRARY_PATH=%s", libDir))
 	if output, err := initCmd.CombinedOutput(); err != nil {
 		os.RemoveAll(config.Dir) // cleanup on failure
+		if pwFile != "" {
+			os.Remove(pwFile)
+		}
 		return nil, fmt.Errorf("initdb failed: %s: %w", string(output), err)
+	}
+	if pwFile != "" {
+		os.Remove(pwFile)
 	}
 
 	// Create log directory (after initdb, which requires empty data dir)
@@ -78,6 +112,7 @@ func (p *PostgreSQLProvider) CreateSandbox(config providers.SandboxConfig) (*pro
 		LibDir:     libDir,
 		Port:       config.Port,
 		LogFile:    logFile,
+		DbUser:     config.DbUser,
 	})
 	for name, content := range scripts {
 		scriptPath := filepath.Join(config.Dir, name)

--- a/providers/postgresql/scripts.go
+++ b/providers/postgresql/scripts.go
@@ -12,6 +12,10 @@ type ScriptOptions struct {
 	LibDir     string
 	Port       int
 	LogFile    string
+	// DbUser is the database user embedded in the generated psql/initdb
+	// invocations. When empty, it defaults to the PostgreSQL superuser
+	// "postgres" to preserve the historical sandbox behavior.
+	DbUser string
 }
 
 const envPreamble = `#!/bin/bash
@@ -21,6 +25,10 @@ unset PGDATA PGPORT PGHOST PGUSER PGDATABASE
 
 func GenerateScripts(opts ScriptOptions) map[string]string {
 	preamble := fmt.Sprintf(envPreamble, opts.LibDir)
+	dbUser := opts.DbUser
+	if dbUser == "" {
+		dbUser = "postgres"
+	}
 
 	return map[string]string{
 		"start": fmt.Sprintf("%s%s/pg_ctl -D %s -l %s start\n",
@@ -35,28 +43,36 @@ func GenerateScripts(opts ScriptOptions) map[string]string {
 		"restart": fmt.Sprintf("%s%s/pg_ctl -D %s -l %s restart\n",
 			preamble, opts.BinDir, opts.DataDir, opts.LogFile),
 
-		"use": fmt.Sprintf("%s%s/psql -h 127.0.0.1 -p %d -U postgres \"$@\"\n",
-			preamble, opts.BinDir, opts.Port),
+		"use": fmt.Sprintf("%s%s/psql -h 127.0.0.1 -p %d -U %s \"$@\"\n",
+			preamble, opts.BinDir, opts.Port, dbUser),
 
-		"clear": fmt.Sprintf("%s%s/pg_ctl -D %s stop -m fast 2>/dev/null\nrm -rf %s\n%s/initdb -D %s --auth=trust --username=postgres\necho \"Sandbox cleared.\"\n",
-			preamble, opts.BinDir, opts.DataDir, opts.DataDir, opts.BinDir, opts.DataDir),
+		"clear": fmt.Sprintf("%s%s/pg_ctl -D %s stop -m fast 2>/dev/null\nrm -rf %s\n%s/initdb -D %s --auth=trust --username=%s\necho \"Sandbox cleared.\"\n",
+			preamble, opts.BinDir, opts.DataDir, opts.DataDir, opts.BinDir, opts.DataDir, dbUser),
 	}
 }
 
 func GenerateCheckReplicationScript(opts ScriptOptions) string {
 	preamble := fmt.Sprintf(envPreamble, opts.LibDir)
-	return fmt.Sprintf(`%s%s/psql -h 127.0.0.1 -p %d -U postgres -c \
+	dbUser := opts.DbUser
+	if dbUser == "" {
+		dbUser = "postgres"
+	}
+	return fmt.Sprintf(`%s%s/psql -h 127.0.0.1 -p %d -U %s -c \
   "SELECT client_addr, state, sent_lsn, write_lsn, flush_lsn, replay_lsn FROM pg_stat_replication;"
-`, preamble, opts.BinDir, opts.Port)
+`, preamble, opts.BinDir, opts.Port, dbUser)
 }
 
 func GenerateCheckRecoveryScript(opts ScriptOptions, replicaPorts []int) string {
 	preamble := fmt.Sprintf(envPreamble, opts.LibDir)
+	dbUser := opts.DbUser
+	if dbUser == "" {
+		dbUser = "postgres"
+	}
 	var b strings.Builder
 	b.WriteString(preamble)
 	for _, port := range replicaPorts {
 		b.WriteString(fmt.Sprintf("echo \"=== Replica port %d ===\"\n", port))
-		b.WriteString(fmt.Sprintf("%s/psql -h 127.0.0.1 -p %d -U postgres -c \"SELECT pg_is_in_recovery();\"\n", opts.BinDir, port))
+		b.WriteString(fmt.Sprintf("%s/psql -h 127.0.0.1 -p %d -U %s -c \"SELECT pg_is_in_recovery();\"\n", opts.BinDir, port, dbUser))
 	}
 	return b.String()
 }

--- a/providers/postgresql/scripts.go
+++ b/providers/postgresql/scripts.go
@@ -23,6 +23,14 @@ export LD_LIBRARY_PATH="%s"
 unset PGDATA PGPORT PGHOST PGUSER PGDATABASE
 `
 
+// shellQuote wraps s in POSIX single quotes (escaping any embedded single
+// quotes) so it is safe to interpolate into a generated bash script. This
+// preserves any valid PostgreSQL role name while neutralizing shell
+// metacharacters in user-supplied values.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
 func GenerateScripts(opts ScriptOptions) map[string]string {
 	preamble := fmt.Sprintf(envPreamble, opts.LibDir)
 	dbUser := opts.DbUser
@@ -44,10 +52,10 @@ func GenerateScripts(opts ScriptOptions) map[string]string {
 			preamble, opts.BinDir, opts.DataDir, opts.LogFile),
 
 		"use": fmt.Sprintf("%s%s/psql -h 127.0.0.1 -p %d -U %s \"$@\"\n",
-			preamble, opts.BinDir, opts.Port, dbUser),
+			preamble, opts.BinDir, opts.Port, shellQuote(dbUser)),
 
 		"clear": fmt.Sprintf("%s%s/pg_ctl -D %s stop -m fast 2>/dev/null\nrm -rf %s\n%s/initdb -D %s --auth=trust --username=%s\necho \"Sandbox cleared.\"\n",
-			preamble, opts.BinDir, opts.DataDir, opts.DataDir, opts.BinDir, opts.DataDir, dbUser),
+			preamble, opts.BinDir, opts.DataDir, opts.DataDir, opts.BinDir, opts.DataDir, shellQuote(dbUser)),
 	}
 }
 
@@ -59,7 +67,7 @@ func GenerateCheckReplicationScript(opts ScriptOptions) string {
 	}
 	return fmt.Sprintf(`%s%s/psql -h 127.0.0.1 -p %d -U %s -c \
   "SELECT client_addr, state, sent_lsn, write_lsn, flush_lsn, replay_lsn FROM pg_stat_replication;"
-`, preamble, opts.BinDir, opts.Port, dbUser)
+`, preamble, opts.BinDir, opts.Port, shellQuote(dbUser))
 }
 
 func GenerateCheckRecoveryScript(opts ScriptOptions, replicaPorts []int) string {
@@ -72,7 +80,7 @@ func GenerateCheckRecoveryScript(opts ScriptOptions, replicaPorts []int) string 
 	b.WriteString(preamble)
 	for _, port := range replicaPorts {
 		b.WriteString(fmt.Sprintf("echo \"=== Replica port %d ===\"\n", port))
-		b.WriteString(fmt.Sprintf("%s/psql -h 127.0.0.1 -p %d -U %s -c \"SELECT pg_is_in_recovery();\"\n", opts.BinDir, port, dbUser))
+		b.WriteString(fmt.Sprintf("%s/psql -h 127.0.0.1 -p %d -U %s -c \"SELECT pg_is_in_recovery();\"\n", opts.BinDir, port, shellQuote(dbUser)))
 	}
 	return b.String()
 }


### PR DESCRIPTION
## Problem

`dbdeployer deploy postgresql` ignores the placement/credential flags that the MySQL deploy honors:

- `--sandbox-home` → always reads `defaults.Defaults().SandboxHome`
- `--port` → always `postgresql.VersionToPort(version)` (+ FindFreePort)
- `--sandbox-directory` → always `pg_sandbox_<port>`
- `--db-user` → hardcoded `postgres` (`initdb --username=postgres`, scripts `-U postgres`)
- `--db-password` → ignored

This blocks per-project / multi-sandbox PostgreSQL deployments (everything lands in a single fixed `~/sandboxes/pg_sandbox_<port>`).

## Fix

**cmd layer** (`cmd/deploy_postgresql.go`): read the flags via `cmd.Flags()`, falling back to current behavior when not provided:
- `sandbox-home` → `getAbsolutePathFromFlag(...)` (same idiom as `single.go`); empty → `defaults.Defaults().SandboxHome`
- `port` → `GetInt("port")`; ≤0 → `VersionToPort` + `FindFreePort`
- `sandbox-directory` → `GetString`; empty → `pg_sandbox_<port>`
- `db-user` / `db-password` → via `flags.Changed(...)` (their registered default is the MySQL `"msandbox"`, never empty — so `Changed()` preserves the PostgreSQL default `postgres`/`""` when the user passes nothing)

**provider layer** (`providers/postgresql/`): propagate `config.DbUser` / `config.DbPassword`:
- `sandbox.go`: `initdb --username=<DbUser>`; password set via a `--pwfile` temp file (0600, removed on success and on every error path)
- `scripts.go`: `ScriptOptions.DbUser`; `-U <dbUser>` in `use`/`clear`/replication/recovery scripts, shell-quoted (empty → `postgres`, byte-identical to before)
- `replication.go`: `CreateReplica` propagates `DbUser` to generated scripts and to the `pg_basebackup` invocation

No new flags registered — all five are inherited persistent flags already listed in `deploy postgresql --help`.

## Verification

`go build`, `go vet`, `gofmt -l`, `go test ./cmd/... ./providers/postgresql/...` all green.

```
# flags honored end-to-end
$ dbdeployer deploy postgresql 18.4 --sandbox-home /tmp/pg --port 55811 --sandbox-directory u1 \
      --db-user testuser --db-password testpass --skip-start --force
PostgreSQL 18.4 sandbox deployed in /tmp/pg/u1 (port: 55811)
$ grep -oE '\-U \w+' /tmp/pg/u1/use   → -U testuser
$ /tmp/pg/u1/start && PGPASSWORD=testpass psql -h 127.0.0.1 -p 55811 -U testuser -d postgres -tAc \
    "select current_user, rolsuper::text from pg_roles where rolname='testuser';"
testuser|t
$ # no parasite 'postgres' role created (initdb --username=testuser)

# fallback (no flags) — original behavior preserved
$ dbdeployer deploy postgresql 18.4 --skip-start --force
PostgreSQL 18.4 sandbox deployed in /Users/.../sandboxes/pg_sandbox_16804 (port: 16804)
$ grep -oE '\-U \w+' .../pg_sandbox_16804/use   → -U postgres
```

## Backward compatibility

With no flags provided, output is byte-identical to before: `postgres` superuser, `pg_sandbox_<port>` name, default home. No behavior change for existing users.

## Relation to other PRs

- **#125** (merged): port computation (`VersionToPort` ProxySQL range, `postgresql.go`). Different concern; this PR keeps using `VersionToPort` for the `--port` fallback — no conflict.
- **#129** (closed): broad PostgreSQL+ProxySQL train touching provider files but not the cmd flag-reading. This PR fixes the root (cmd reads the flags) plus provider propagation.

Tested on macOS, PostgreSQL 18.4.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PostgreSQL sandbox deployments now honor custom binary, home, port, and directory settings.
  * Custom database usernames and passwords are supported during sandbox creation.
  * Replica setup and generated maintenance scripts now use the configured database username.
  * PostgreSQL command parameters safely support usernames containing special characters.

* **Bug Fixes**
  * Improved validation for sandbox paths and directories.
  * Preserved default PostgreSQL behavior when custom settings are not provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->