### PR TITLE
fix(replication): prevent excessive wait times after deploy (fixes #131)

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -112,6 +112,8 @@ jobs:
       MAX_DEPLOY_SECONDS: 45
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@v5
         with:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -100,6 +100,62 @@ jobs:
           ./dbdeployer delete all --skip-confirm 2>/dev/null || true
           pkill -9 -u "$USER" mysqld 2>/dev/null || true
 
+  # Time-bounded deploy test: verifies that "deploy replication" completes
+  # within MAX_DEPLOY_SECONDS and replicas serve queries immediately after
+  # deploy (regression test for issue #131).
+  deploy-time-budget:
+    name: Deploy time budget (8.4)
+    runs-on: ubuntu-22.04
+    env:
+      GO111MODULE: on
+      SANDBOX_BINARY: ${{ github.workspace }}/opt/mysql
+      MAX_DEPLOY_SECONDS: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+
+      - name: Install system libraries
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libaio1 libnuma1 libncurses5 libldap-2.5-0
+
+      - name: Build dbdeployer
+        run: go build -o dbdeployer .
+
+      - name: Cache MySQL tarball
+        uses: actions/cache@v4
+        with:
+          path: /tmp/mysql-tarball
+          key: mysql-8.4.4-linux-x86_64-v1
+
+      - name: Download MySQL 8.4.4
+        run: |
+          mkdir -p /tmp/mysql-tarball
+          TARBALL="mysql-8.4.4-linux-glibc2.17-x86_64.tar.xz"
+          curl -L -f -o "/tmp/mysql-tarball/$TARBALL" \
+            "https://dev.mysql.com/get/Downloads/MySQL-8.4/$TARBALL" \
+            || curl -L -f -o "/tmp/mysql-tarball/$TARBALL" \
+            "https://downloads.mysql.com/archives/get/p/23/file/$TARBALL"
+          ls -lh "/tmp/mysql-tarball/$TARBALL"
+
+      - name: Unpack MySQL
+        run: |
+          mkdir -p "$SANDBOX_BINARY"
+          ./dbdeployer unpack "/tmp/mysql-tarball/mysql-8.4.4-linux-glibc2.17-x86_64.tar.xz" \
+            --sandbox-binary="$SANDBOX_BINARY"
+
+      - name: Run deploy time budget test
+        run: ./test/deploy-time-budget.sh
+
+      - name: Cleanup
+        if: always()
+        run: |
+          ./dbdeployer delete all --skip-confirm 2>/dev/null || true
+          pkill -9 -u "$USER" mysqld 2>/dev/null || true
+
   # Test Percona Server: single + replication with data verification
   percona-test:
     name: Percona Server (${{ matrix.percona-version }})

--- a/sandbox/templates/replication/init_slaves.gotxt
+++ b/sandbox/templates/replication/init_slaves.gotxt
@@ -14,7 +14,7 @@ cd "$SBDIR"
 # Observed especially with MySQL 8.4+ and 9.x.
 wait_until_replica_ready() {
     local use_cmd=${1:-$SBDIR/use}
-    local max_attempts=${2:-60}
+    local max_attempts=${2:-20}
     local sleep_sec=${3:-1}
     for i in $(seq 1 $max_attempts); do
         if $use_cmd -BN -e "SELECT 1;" >/dev/null 2>&1 ; then
@@ -39,7 +39,7 @@ echo "initializing {{.SlaveLabel}} {{.Node}}"
 echo '{{.ChangeMasterTo}}  {{.MasterHostParam}}="{{.MasterIp}}",  {{.MasterPortParam}}={{.MasterPort}},  {{.MasterUserParam}}="{{.RplUser}}",  {{.MasterPasswordParam}}="{{.RplPassword}}" {{.MasterAutoPosition}} {{.ChangeMasterExtra}}' | $SBDIR/{{.NodeLabel}}{{.Node}}/use -u root
 $SBDIR/{{.NodeLabel}}{{.Node}}/use -u root -e '{{.StartReplica}}'
 # Ensure the replica is serving queries before we return from initialization.
-wait_until_replica_ready "$SBDIR/{{.NodeLabel}}{{.Node}}/use" 60 1
+wait_until_replica_ready "$SBDIR/{{.NodeLabel}}{{.Node}}/use" 20 1
 {{end}}
 if [ -x ./post_initialization ]
 then

--- a/sandbox/templates/replication/init_slaves.gotxt
+++ b/sandbox/templates/replication/init_slaves.gotxt
@@ -12,12 +12,16 @@ cd "$SBDIR"
 # initialization to prevent the race where the first client command on a
 # just-started replica fails with "Access denied" or connection errors.
 # Observed especially with MySQL 8.4+ and 9.x.
+# NOTE: init_slaves exports NOPASSWORD=1 for the root steps; that must NOT
+# leak into this probe, or 'use' would drop the sandbox-user password and the
+# check would fail with "Access denied" even once the user exists (burning the
+# whole budget). Clear NOPASSWORD for the probe so it authenticates normally.
 wait_until_replica_ready() {
     local use_cmd=${1:-$SBDIR/use}
     local max_attempts=${2:-20}
     local sleep_sec=${3:-1}
     for i in $(seq 1 $max_attempts); do
-        if $use_cmd -BN -e "SELECT 1;" >/dev/null 2>&1 ; then
+        if NOPASSWORD= $use_cmd -BN -e "SELECT 1;" >/dev/null 2>&1 ; then
             return 0
         fi
         sleep $sleep_sec

--- a/sandbox/templates/replication/init_slaves_84.gotxt
+++ b/sandbox/templates/replication/init_slaves_84.gotxt
@@ -13,12 +13,16 @@ cd "$SBDIR"
 # initialization to prevent the race where the first client command on a
 # just-started replica fails with "Access denied" or connection errors.
 # Observed especially with MySQL 8.4+ and 9.x.
+# NOTE: init_slaves exports NOPASSWORD=1 for the root steps; that must NOT
+# leak into this probe, or 'use' would drop the sandbox-user password and the
+# check would fail with "Access denied" even once the user exists (burning the
+# whole budget). Clear NOPASSWORD for the probe so it authenticates normally.
 wait_until_replica_ready() {
     local use_cmd=${1:-$SBDIR/use}
     local max_attempts=${2:-20}
     local sleep_sec=${3:-1}
     for i in $(seq 1 $max_attempts); do
-        if $use_cmd -BN -e "SELECT 1;" >/dev/null 2>&1 ; then
+        if NOPASSWORD= $use_cmd -BN -e "SELECT 1;" >/dev/null 2>&1 ; then
             return 0
         fi
         sleep $sleep_sec

--- a/sandbox/templates/replication/init_slaves_84.gotxt
+++ b/sandbox/templates/replication/init_slaves_84.gotxt
@@ -15,7 +15,7 @@ cd "$SBDIR"
 # Observed especially with MySQL 8.4+ and 9.x.
 wait_until_replica_ready() {
     local use_cmd=${1:-$SBDIR/use}
-    local max_attempts=${2:-60}
+    local max_attempts=${2:-20}
     local sleep_sec=${3:-1}
     for i in $(seq 1 $max_attempts); do
         if $use_cmd -BN -e "SELECT 1;" >/dev/null 2>&1 ; then
@@ -40,7 +40,7 @@ echo "initializing {{.SlaveLabel}} {{.Node}}"
 echo '{{.ChangeMasterTo}}  {{.MasterHostParam}}="{{.MasterIp}}",  {{.MasterPortParam}}={{.MasterPort}},  {{.MasterUserParam}}="{{.RplUser}}",  {{.MasterPasswordParam}}="{{.RplPassword}}" {{.MasterAutoPosition}} {{.ChangeMasterExtra}}' | $SBDIR/{{.NodeLabel}}{{.Node}}/use -u root
 $SBDIR/{{.NodeLabel}}{{.Node}}/use -u root -e '{{.StartReplica}}'
 # Ensure the replica is serving queries before we return from initialization.
-wait_until_replica_ready "$SBDIR/{{.NodeLabel}}{{.Node}}/use" 60 1
+wait_until_replica_ready "$SBDIR/{{.NodeLabel}}{{.Node}}/use" 20 1
 {{end}}
 if [ -x ./post_initialization ]
 then

--- a/sandbox/templates/single/sb_include.gotxt
+++ b/sandbox/templates/single/sb_include.gotxt
@@ -122,11 +122,15 @@ function wait_until_wsrep_ready
         echo "WARNING: cannot connect as root via socket after $((connect_attempts * connect_sleep))s" >&2
         return 1
     fi
-    # Connected: empty SHOW STATUS means wsrep_ready does not exist (non-Galera).
+    # Connected: a SHOW STATUS that succeeds with no rows means wsrep_ready
+    # does not exist (non-Galera) -> short-circuit. Only the successful-empty
+    # case may bypass the wait: if the probe itself fails, fall through to the
+    # polling loop so a transient error cannot skip the wsrep_ready gate.
     local wsrep_check
-    wsrep_check=$($mysql_cmd --no-defaults -S "$SOCKET_FILE" -u root -BN -e "SHOW STATUS LIKE 'wsrep_ready';" 2>/dev/null)
-    if [ -z "$wsrep_check" ]; then
-        return 0
+    if wsrep_check=$($mysql_cmd --no-defaults -S "$SOCKET_FILE" -u root -BN -e "SHOW STATUS LIKE 'wsrep_ready';" 2>/dev/null); then
+        if [ -z "$wsrep_check" ]; then
+            return 0
+        fi
     fi
     for i in $(seq 1 $max_attempts); do
         if $mysql_cmd --no-defaults -S "$SOCKET_FILE" -u root -BN -e "SHOW STATUS LIKE 'wsrep_ready';" 2>/dev/null | grep -qiE 'wsrep_ready[[:space:]]+ON'; then

--- a/sandbox/templates/single/sb_include.gotxt
+++ b/sandbox/templates/single/sb_include.gotxt
@@ -148,13 +148,17 @@ function wait_until_wsrep_ready
 # just-started replica fails with "Access denied" or connection errors.
 # Observed especially with MySQL 8.4+ and 9.x.
 # Usage: wait_until_replica_ready "$SBDIR/s1/use" 20 1
+# NOTE: callers (e.g. init_slaves) may export NOPASSWORD=1 for root steps; it
+# must not leak into this probe, or 'use' would drop the sandbox-user password
+# and the check would fail with "Access denied" even once the user exists.
+# Clear NOPASSWORD for the probe so it authenticates normally.
 function wait_until_replica_ready
 {
     local use_cmd=${1:-$SBDIR/use}
     local max_attempts=${2:-20}
     local sleep_sec=${3:-1}
     for i in $(seq 1 $max_attempts); do
-        if $use_cmd -BN -e "SELECT 1;" >/dev/null 2>&1 ; then
+        if NOPASSWORD= $use_cmd -BN -e "SELECT 1;" >/dev/null 2>&1 ; then
             return 0
         fi
         sleep $sleep_sec

--- a/sandbox/templates/single/sb_include.gotxt
+++ b/sandbox/templates/single/sb_include.gotxt
@@ -70,11 +70,16 @@ function check_output
 # Wait until wsrep_ready is ON for Galera/PXC nodes.
 # This prevents grants and user DML from running before the node
 # has joined the cluster.
+# On non-Galera servers the status variable does not exist and
+# this function returns immediately (no delay).
 function wait_until_wsrep_ready
 {
     local use_cmd=${1:-$SBDIR/use}
     local max_attempts=${2:-60}
     local sleep_sec=${3:-2}
+    if ! $use_cmd -BN -e "SHOW STATUS LIKE 'wsrep_ready';" 2>/dev/null | grep -q 'wsrep_ready'; then
+        return 0
+    fi
     for i in $(seq 1 $max_attempts); do
         if $use_cmd -BN -e "SHOW STATUS LIKE 'wsrep_ready';" 2>/dev/null | grep -qi 'ON' ; then
             return 0
@@ -90,11 +95,11 @@ function wait_until_wsrep_ready
 # initialization to prevent the race where the first client command on a
 # just-started replica fails with "Access denied" or connection errors.
 # Observed especially with MySQL 8.4+ and 9.x.
-# Usage: wait_until_replica_ready "$SBDIR/s1/use" 60 1
+# Usage: wait_until_replica_ready "$SBDIR/s1/use" 20 1
 function wait_until_replica_ready
 {
     local use_cmd=${1:-$SBDIR/use}
-    local max_attempts=${2:-60}
+    local max_attempts=${2:-20}
     local sleep_sec=${3:-1}
     for i in $(seq 1 $max_attempts); do
         if $use_cmd -BN -e "SELECT 1;" >/dev/null 2>&1 ; then

--- a/sandbox/templates/single/sb_include.gotxt
+++ b/sandbox/templates/single/sb_include.gotxt
@@ -72,28 +72,25 @@ function check_output
 # has joined the cluster.
 # On non-Galera servers the status variable does not exist and
 # this function returns immediately (no delay).
-# Note: the initial detection connects as root via socket (no password),
-# because the sandbox user (msandbox) may not exist yet. Once the
-# Galera/PXC nature is confirmed, the function polls using the caller-
-# provided use_cmd (typically the sandbox user).
+# Detection and polling connect as root via socket (no password),
+# because the sandbox user (msandbox) may not exist yet on fresh
+# nodes (load_grants has not run).
 function wait_until_wsrep_ready
 {
-    local use_cmd=${1:-$SBDIR/use}
-    local max_attempts=${2:-60}
-    local sleep_sec=${3:-2}
-    # Detect Galera by connecting as root (no password) via the local
-    # socket. If wsrep_ready exists, this is a Galera/PXC node.
-    local wsrep_check
+    local max_attempts=${1:-60}
+    local sleep_sec=${2:-2}
+    local mysql_cmd
     if [ -x "$CLIENT_BASEDIR/bin/mysql" ]; then
-        wsrep_check=$("$CLIENT_BASEDIR/bin/mysql" --no-defaults -S "$SOCKET_FILE" -u root -BN -e "SHOW STATUS LIKE 'wsrep_ready';" 2>/dev/null)
+        mysql_cmd="$CLIENT_BASEDIR/bin/mysql"
     else
-        wsrep_check=$("$BASEDIR/bin/mysql" --no-defaults -S "$SOCKET_FILE" -u root -BN -e "SHOW STATUS LIKE 'wsrep_ready';" 2>/dev/null)
+        mysql_cmd="$BASEDIR/bin/mysql"
     fi
+    local wsrep_check=$($mysql_cmd --no-defaults -S "$SOCKET_FILE" -u root -BN -e "SHOW STATUS LIKE 'wsrep_ready';" 2>/dev/null)
     if [ -z "$wsrep_check" ]; then
         return 0
     fi
     for i in $(seq 1 $max_attempts); do
-        if $use_cmd -BN -e "SHOW STATUS LIKE 'wsrep_ready';" 2>/dev/null | grep -qi 'ON' ; then
+        if $mysql_cmd --no-defaults -S "$SOCKET_FILE" -u root -BN -e "SHOW STATUS LIKE 'wsrep_ready';" 2>/dev/null | grep -qi 'ON' ; then
             return 0
         fi
         sleep $sleep_sec

--- a/sandbox/templates/single/sb_include.gotxt
+++ b/sandbox/templates/single/sb_include.gotxt
@@ -72,12 +72,24 @@ function check_output
 # has joined the cluster.
 # On non-Galera servers the status variable does not exist and
 # this function returns immediately (no delay).
+# Note: the initial detection connects as root via socket (no password),
+# because the sandbox user (msandbox) may not exist yet. Once the
+# Galera/PXC nature is confirmed, the function polls using the caller-
+# provided use_cmd (typically the sandbox user).
 function wait_until_wsrep_ready
 {
     local use_cmd=${1:-$SBDIR/use}
     local max_attempts=${2:-60}
     local sleep_sec=${3:-2}
-    if ! $use_cmd -BN -e "SHOW STATUS LIKE 'wsrep_ready';" 2>/dev/null | grep -q 'wsrep_ready'; then
+    # Detect Galera by connecting as root (no password) via the local
+    # socket. If wsrep_ready exists, this is a Galera/PXC node.
+    local wsrep_check
+    if [ -x "$CLIENT_BASEDIR/bin/mysql" ]; then
+        wsrep_check=$("$CLIENT_BASEDIR/bin/mysql" --no-defaults -S "$SOCKET_FILE" -u root -BN -e "SHOW STATUS LIKE 'wsrep_ready';" 2>/dev/null)
+    else
+        wsrep_check=$("$BASEDIR/bin/mysql" --no-defaults -S "$SOCKET_FILE" -u root -BN -e "SHOW STATUS LIKE 'wsrep_ready';" 2>/dev/null)
+    fi
+    if [ -z "$wsrep_check" ]; then
         return 0
     fi
     for i in $(seq 1 $max_attempts); do

--- a/sandbox/templates/single/sb_include.gotxt
+++ b/sandbox/templates/single/sb_include.gotxt
@@ -71,26 +71,65 @@ function check_output
 # This prevents grants and user DML from running before the node
 # has joined the cluster.
 # On non-Galera servers the status variable does not exist and
-# this function returns immediately (no delay).
+# this function returns immediately (no delay) once the server accepts
+# connections.
 # Detection and polling connect as root via socket (no password),
 # because the sandbox user (msandbox) may not exist yet on fresh
 # nodes (load_grants has not run).
+# Connect failures are NOT treated as non-Galera: the pid file can
+# appear before the server accepts connections, so we retry until
+# root can connect, then check whether wsrep_ready exists.
 function wait_until_wsrep_ready
 {
     local max_attempts=${1:-60}
     local sleep_sec=${2:-2}
-    local mysql_cmd
-    if [ -x "$CLIENT_BASEDIR/bin/mysql" ]; then
-        mysql_cmd="$CLIENT_BASEDIR/bin/mysql"
+    local mysql_cmd=""
+    local clients
+    if [ "$FLAVOR" = "mariadb" ]; then
+        clients="mariadb mysql"
     else
-        mysql_cmd="$BASEDIR/bin/mysql"
+        clients="mysql mariadb"
     fi
-    local wsrep_check=$($mysql_cmd --no-defaults -S "$SOCKET_FILE" -u root -BN -e "SHOW STATUS LIKE 'wsrep_ready';" 2>/dev/null)
+    local d c
+    for d in "$CLIENT_BASEDIR/bin" "$BASEDIR/bin"; do
+        for c in $clients; do
+            if [ -x "$d/$c" ]; then
+                mysql_cmd="$d/$c"
+                break 2
+            fi
+        done
+    done
+    if [ -z "$mysql_cmd" ]; then
+        echo "WARNING: no mysql/mariadb client found under $CLIENT_BASEDIR/bin or $BASEDIR/bin" >&2
+        return 1
+    fi
+    # Wait until root can connect via socket. Empty query output before
+    # connect succeeds must not be treated as "non-Galera".
+    # Keep this budget separate and modest: pid-file can appear slightly
+    # before the server accepts connections, but not for minutes.
+    local connect_attempts=30
+    local connect_sleep=1
+    local connected=0
+    local i
+    for i in $(seq 1 $connect_attempts); do
+        if $mysql_cmd --no-defaults -S "$SOCKET_FILE" -u root -BN -e "SELECT 1" >/dev/null 2>&1; then
+            connected=1
+            break
+        fi
+        sleep $connect_sleep
+    done
+    if [ "$connected" -ne 1 ]; then
+        echo "WARNING: cannot connect as root via socket after $((connect_attempts * connect_sleep))s" >&2
+        return 1
+    fi
+    # Connected: empty SHOW STATUS means wsrep_ready does not exist (non-Galera).
+    local wsrep_check
+    wsrep_check=$($mysql_cmd --no-defaults -S "$SOCKET_FILE" -u root -BN -e "SHOW STATUS LIKE 'wsrep_ready';" 2>/dev/null)
     if [ -z "$wsrep_check" ]; then
         return 0
     fi
     for i in $(seq 1 $max_attempts); do
-        if $mysql_cmd --no-defaults -S "$SOCKET_FILE" -u root -BN -e "SHOW STATUS LIKE 'wsrep_ready';" 2>/dev/null | grep -qi 'ON' ; then
+        if $mysql_cmd --no-defaults -S "$SOCKET_FILE" -u root -BN -e "SHOW STATUS LIKE 'wsrep_ready';" 2>/dev/null | grep -qiE 'wsrep_ready[[:space:]]+ON'; then
             return 0
         fi
         sleep $sleep_sec

--- a/sandbox/templates/single/wait_wsrep_after_start.gotxt
+++ b/sandbox/templates/single/wait_wsrep_after_start.gotxt
@@ -5,5 +5,5 @@ source {{.SandboxDir}}/sb_include
 
 # Best-effort wait for wsrep cluster readiness before grants/DML.
 # This script is safe to run even on non-Galera sandboxes (exits 0 quickly).
-wait_until_wsrep_ready "$SBDIR/use" 60 2 || true
+wait_until_wsrep_ready 60 2 || true
 exit 0

--- a/sandbox/templates_flavor_test.go
+++ b/sandbox/templates_flavor_test.go
@@ -288,6 +288,11 @@ func TestSbInclude_WaitUntilWsrepReady_DetectsNonGalera(t *testing.T) {
 	if !strings.Contains(result, `if [ -z "$wsrep_check" ]; then`) {
 		t.Error("wait_until_wsrep_ready must check if wsrep_ready variable exists (regression: #131 2-min delay on non-Galera)")
 	}
+	// The empty-result short-circuit must be gated on the probe's exit status,
+	// so a failed SHOW STATUS cannot be misread as "non-Galera" (CodeRabbit).
+	if !strings.Contains(result, `if wsrep_check=$($mysql_cmd`) {
+		t.Error("wait_until_wsrep_ready must only short-circuit when the wsrep probe succeeds (check exit status)")
+	}
 	// Root via socket (no password) before load_grants creates msandbox.
 	if !strings.Contains(result, `--no-defaults -S "$SOCKET_FILE" -u root`) {
 		t.Error("wait_until_wsrep_ready must connect as root via socket for the guard check")

--- a/sandbox/templates_flavor_test.go
+++ b/sandbox/templates_flavor_test.go
@@ -276,22 +276,33 @@ func TestSbInclude_WaitUntilWsrepReady_DetectsNonGalera(t *testing.T) {
 	data := baseTemplateData("mysql")
 	result := renderTemplate(t, sbIncludeTemplate, data)
 
-	// The early-return guard: connect as root via socket and check if the
-	// query returns any rows. On non-Galera the output is empty and the
-	// function returns 0 immediately without blocking.
+	// Must wait for a successful root connection before deciding Galera vs not.
+	// Empty output while the server is still starting must not short-circuit.
+	if !strings.Contains(result, `SELECT 1`) {
+		t.Error("wait_until_wsrep_ready must wait for root socket connect before Galera detection")
+	}
+	if !strings.Contains(result, `if [ "$connected" -ne 1 ]; then`) {
+		t.Error("wait_until_wsrep_ready must fail (not short-circuit) when root cannot connect")
+	}
+	// After connect succeeds: empty SHOW STATUS means non-Galera → return 0.
 	if !strings.Contains(result, `if [ -z "$wsrep_check" ]; then`) {
 		t.Error("wait_until_wsrep_ready must check if wsrep_ready variable exists (regression: #131 2-min delay on non-Galera)")
 	}
-	// The guard connects as root (no password) via socket so it works
-	// before the sandbox user (msandbox) has been created by load_grants.
+	// Root via socket (no password) before load_grants creates msandbox.
 	if !strings.Contains(result, `--no-defaults -S "$SOCKET_FILE" -u root`) {
 		t.Error("wait_until_wsrep_ready must connect as root via socket for the guard check")
 	}
-	// Both detection AND polling use root socket to work before load_grants.
-	if !strings.Contains(result, "$mysql_cmd --no-defaults -S \"$SOCKET_FILE\" -u root -BN -e \"SHOW STATUS LIKE 'wsrep_ready';\"") {
-		t.Error("wait_until_wsrep_ready must use root socket for polling, not $SBDIR/use (msandbox does not exist yet)")
+	// Shell-level FLAVOR if: both preference orders must be present.
+	if !strings.Contains(result, `clients="mysql mariadb"`) {
+		t.Error("wait_until_wsrep_ready must prefer mysql client for non-MariaDB flavor")
 	}
-	// The default max_attempts for wsrep should not exceed the budget.
+	if !strings.Contains(result, `clients="mariadb mysql"`) {
+		t.Error("wait_until_wsrep_ready must prefer mariadb client when FLAVOR=mariadb")
+	}
+	// Match wsrep_ready ON specifically, not a bare 'ON' substring.
+	if !strings.Contains(result, `wsrep_ready[[:space:]]+ON`) {
+		t.Error("wait_until_wsrep_ready must match wsrep_ready ON specifically")
+	}
 	if !strings.Contains(result, "local max_attempts=${1:-60}") {
 		t.Error("wait_until_wsrep_ready default max_attempts must remain 60 for Galera nodes, but the guard above must short-circuit on non-Galera")
 	}
@@ -307,7 +318,7 @@ func TestSbInclude_WaitUntilReplicaReady_BoundedWait(t *testing.T) {
 	result := renderTemplate(t, sbIncludeTemplate, data)
 
 	// wait_until_replica_ready must have max_attempts=${2:-20}
-	// (wait_until_wsrep_ready keeps ${2:-60} for Galera nodes).
+	// (wait_until_wsrep_ready keeps ${1:-60} for Galera nodes).
 	if !strings.Contains(result, `max_attempts=${2:-20}`) {
 		t.Errorf("wait_until_replica_ready max_attempts should be 20 to keep total wait ≤ %ds",
 			maxAllowedWaitSeconds)

--- a/sandbox/templates_flavor_test.go
+++ b/sandbox/templates_flavor_test.go
@@ -276,11 +276,16 @@ func TestSbInclude_WaitUntilWsrepReady_DetectsNonGalera(t *testing.T) {
 	data := baseTemplateData("mysql")
 	result := renderTemplate(t, sbIncludeTemplate, data)
 
-	// The early-return guard: grep for 'wsrep_ready' string in the output
-	// of SHOW STATUS. On non-Galera the output is empty and the function
-	// returns 0 immediately.
-	if !strings.Contains(result, `grep -q 'wsrep_ready'`) {
+	// The early-return guard: connect as root via socket and check if the
+	// query returns any rows. On non-Galera the output is empty and the
+	// function returns 0 immediately without blocking.
+	if !strings.Contains(result, `if [ -z "$wsrep_check" ]; then`) {
 		t.Error("wait_until_wsrep_ready must check if wsrep_ready variable exists (regression: #131 2-min delay on non-Galera)")
+	}
+	// The guard connects as root (no password) so it works before the
+	// sandbox user (msandbox) has been created by load_grants.
+	if !strings.Contains(result, `--no-defaults -S "$SOCKET_FILE" -u root`) {
+		t.Error("wait_until_wsrep_ready must connect as root via socket for the guard check")
 	}
 	// The default max_attempts for wsrep should not exceed the budget.
 	if !strings.Contains(result, "local max_attempts=${2:-60}") {

--- a/sandbox/templates_flavor_test.go
+++ b/sandbox/templates_flavor_test.go
@@ -245,6 +245,13 @@ func TestInitSlavesTemplates_IncludeReplicaReadyWait(t *testing.T) {
 		if !strings.Contains(result, expectedWarning) {
 			t.Errorf("%s template must include a timeout warning message", name)
 		}
+		// The probe must clear NOPASSWORD so it authenticates as the sandbox
+		// user. init_slaves exports NOPASSWORD=1 for the root steps; if it leaks
+		// into the probe, 'use' drops the password and the check fails with
+		// "Access denied" for the whole budget (~20s wasted on every deploy).
+		if !strings.Contains(result, `NOPASSWORD= $use_cmd -BN -e "SELECT 1;"`) {
+			t.Errorf("%s template must clear NOPASSWORD for the replica-ready probe", name)
+		}
 	}
 }
 
@@ -327,5 +334,10 @@ func TestSbInclude_WaitUntilReplicaReady_BoundedWait(t *testing.T) {
 	if !strings.Contains(result, `max_attempts=${2:-20}`) {
 		t.Errorf("wait_until_replica_ready max_attempts should be 20 to keep total wait ≤ %ds",
 			maxAllowedWaitSeconds)
+	}
+	// The probe must clear NOPASSWORD so it authenticates as the sandbox user
+	// (callers such as init_slaves export NOPASSWORD=1 for the root steps).
+	if !strings.Contains(result, `NOPASSWORD= $use_cmd -BN -e "SELECT 1;"`) {
+		t.Error("wait_until_replica_ready must clear NOPASSWORD for the probe, or it fails with Access denied and burns the whole budget")
 	}
 }

--- a/sandbox/templates_flavor_test.go
+++ b/sandbox/templates_flavor_test.go
@@ -282,13 +282,17 @@ func TestSbInclude_WaitUntilWsrepReady_DetectsNonGalera(t *testing.T) {
 	if !strings.Contains(result, `if [ -z "$wsrep_check" ]; then`) {
 		t.Error("wait_until_wsrep_ready must check if wsrep_ready variable exists (regression: #131 2-min delay on non-Galera)")
 	}
-	// The guard connects as root (no password) so it works before the
-	// sandbox user (msandbox) has been created by load_grants.
+	// The guard connects as root (no password) via socket so it works
+	// before the sandbox user (msandbox) has been created by load_grants.
 	if !strings.Contains(result, `--no-defaults -S "$SOCKET_FILE" -u root`) {
 		t.Error("wait_until_wsrep_ready must connect as root via socket for the guard check")
 	}
+	// Both detection AND polling use root socket to work before load_grants.
+	if !strings.Contains(result, "$mysql_cmd --no-defaults -S \"$SOCKET_FILE\" -u root -BN -e \"SHOW STATUS LIKE 'wsrep_ready';\"") {
+		t.Error("wait_until_wsrep_ready must use root socket for polling, not $SBDIR/use (msandbox does not exist yet)")
+	}
 	// The default max_attempts for wsrep should not exceed the budget.
-	if !strings.Contains(result, "local max_attempts=${2:-60}") {
+	if !strings.Contains(result, "local max_attempts=${1:-60}") {
 		t.Error("wait_until_wsrep_ready default max_attempts must remain 60 for Galera nodes, but the guard above must short-circuit on non-Galera")
 	}
 }

--- a/sandbox/templates_flavor_test.go
+++ b/sandbox/templates_flavor_test.go
@@ -71,10 +71,10 @@ func TestStartTemplate_MySQL(t *testing.T) {
 	data := baseTemplateData("mysql")
 	result := renderTemplate(t, startTemplate, data)
 	if !strings.Contains(result, `MYSQLD_SAFE="bin/mysqld_safe"`) {
-		t.Error("mysql start template should use mysqld_safe")
+		t.Error("mysql start template should default to mysqld_safe")
 	}
-	if strings.Contains(result, "mariadbd-safe") {
-		t.Error("mysql start template should not reference mariadbd-safe")
+	if !strings.Contains(result, `MYSQLD_SAFE="bin/mariadbd-safe"`) {
+		t.Error("mysql start template must have a mariadb branch (shell-level if)")
 	}
 }
 
@@ -89,18 +89,18 @@ func TestStartTemplate_MariaDB(t *testing.T) {
 func TestStopTemplate_MySQL(t *testing.T) {
 	data := baseTemplateData("mysql")
 	result := renderTemplate(t, stopTemplate, data)
-	if !strings.Contains(result, `$CLIENT_BASEDIR/bin/mysqladmin`) {
-		t.Error("mysql stop template should use mysqladmin")
+	if !strings.Contains(result, `MYSQL_ADMIN="$CLIENT_BASEDIR/bin/mysqladmin"`) {
+		t.Error("mysql stop template should default to mysqladmin")
 	}
-	if strings.Contains(result, "mariadb-admin") {
-		t.Error("mysql stop template should not reference mariadb-admin")
+	if !strings.Contains(result, `MYSQL_ADMIN="$CLIENT_BASEDIR/bin/mariadb-admin"`) {
+		t.Error("mysql stop template must have a mariadb branch (shell-level if)")
 	}
 }
 
 func TestStopTemplate_MariaDB(t *testing.T) {
 	data := baseTemplateData("mariadb")
 	result := renderTemplate(t, stopTemplate, data)
-	if !strings.Contains(result, `$CLIENT_BASEDIR/bin/mariadb-admin`) {
+	if !strings.Contains(result, `MYSQL_ADMIN="$CLIENT_BASEDIR/bin/mariadb-admin"`) {
 		t.Error("mariadb stop template should use mariadb-admin")
 	}
 }
@@ -108,18 +108,18 @@ func TestStopTemplate_MariaDB(t *testing.T) {
 func TestUseTemplate_MySQL(t *testing.T) {
 	data := baseTemplateData("mysql")
 	result := renderTemplate(t, useTemplate, data)
-	if !strings.Contains(result, `$CLIENT_BASEDIR/bin/mysql"`) {
-		t.Error("mysql use template should use mysql client")
+	if !strings.Contains(result, `MYCLIENT="mysql"`) {
+		t.Error("mysql use template should default to mysql client")
 	}
-	if strings.Contains(result, `bin/mariadb`) {
-		t.Error("mysql use template should not reference mariadb client")
+	if !strings.Contains(result, `MYCLIENT="mariadb"`) {
+		t.Error("mysql use template must have a mariadb branch (shell-level if)")
 	}
 }
 
 func TestUseTemplate_MariaDB(t *testing.T) {
 	data := baseTemplateData("mariadb")
 	result := renderTemplate(t, useTemplate, data)
-	if !strings.Contains(result, `$CLIENT_BASEDIR/bin/mariadb"`) {
+	if !strings.Contains(result, `MYCLIENT="mariadb"`) {
 		t.Error("mariadb use template should use mariadb client")
 	}
 }
@@ -174,17 +174,17 @@ func TestReplicationStopAndUse_DelegateToSingleTemplates(t *testing.T) {
 		useResult := renderTemplate(t, useTemplate, data)
 
 		if flavor == "mariadb" {
-			if !strings.Contains(stopResult, "mariadb-admin") {
+			if !strings.Contains(stopResult, `MYSQL_ADMIN="$CLIENT_BASEDIR/bin/mariadb-admin"`) {
 				t.Errorf("replication node stop for mariadb should use mariadb-admin")
 			}
-			if !strings.Contains(useResult, "bin/mariadb") {
+			if !strings.Contains(useResult, `MYCLIENT="mariadb"`) {
 				t.Errorf("replication node use for mariadb should use mariadb client")
 			}
 		} else {
-			if !strings.Contains(stopResult, "mysqladmin") {
+			if !strings.Contains(stopResult, `MYSQL_ADMIN="$CLIENT_BASEDIR/bin/mysqladmin"`) {
 				t.Errorf("replication node stop for mysql should use mysqladmin")
 			}
-			if !strings.Contains(useResult, "bin/mysql") {
+			if !strings.Contains(useResult, `MYCLIENT="mysql"`) {
 				t.Errorf("replication node use for mysql should use mysql client")
 			}
 		}

--- a/sandbox/templates_flavor_test.go
+++ b/sandbox/templates_flavor_test.go
@@ -22,26 +22,39 @@ import (
 	"github.com/ProxySQL/dbdeployer/common"
 )
 
+// maxAllowedWaitSeconds is the maximum total wait time (in seconds) that any
+// generated shell script should impose during normal operation on non-Galera
+// MySQL. Setting this too high hides regressions (e.g. the 120s wsrep spin on
+// vanilla MySQL from commit a2caf94); setting it too low causes flaky failures
+// on slow CI runners. This value must be ≥ the per-node replica-ready poll.
+const maxAllowedWaitSeconds = 30
+
 func baseTemplateData(flavor string) common.StringMap {
 	return common.StringMap{
-		"ShellPath":      "/bin/bash",
-		"SandboxDir":     "/tmp/sandbox/rsandbox_1234",
-		"Basedir":        "/opt/mysql/11.4",
-		"ClientBasedir":  "/opt/mysql/11.4",
-		"Copyright":      "# test",
-		"CustomMysqld":  "",
-		"Port":           "1234",
-		"Flavor":         flavor,
-		"Version":        "11.4.10",
-		"VersionMajor":   "11",
-		"VersionMinor":   "4",
-		"VersionRev":     "10",
+		"ShellPath":       "/bin/bash",
+		"SandboxDir":      "/tmp/sandbox/rsandbox_1234",
+		"Basedir":         "/opt/mysql/11.4",
+		"ClientBasedir":   "/opt/mysql/11.4",
+		"Copyright":       "# test",
+		"CustomMysqld":    "",
+		"Port":            "1234",
+		"MysqlXPort":      "0",
+		"MysqlXSocket":    "",
+		"AdminPort":       "0",
+		"ServerId":        "100",
+		"SocketFile":      "/tmp/sandbox/mysql_sandbox.sock",
+		"Flavor":          flavor,
+		"Version":         "11.4.10",
+		"VersionMajor":    "11",
+		"VersionMinor":    "4",
+		"VersionRev":      "10",
 		"SortableVersion": "011004010",
-		"HistoryDir":     "/tmp/sandbox/rsandbox_1234",
-		"SbHost":         "127.0.0.1",
-		"SBType":         "replication-node",
-		"EngineClause":   "",
-		"TemplateName":   "test",
+		"HistoryDir":      "/tmp/sandbox/rsandbox_1234",
+		"SbHost":          "127.0.0.1",
+		"SBType":          "replication-node",
+		"SandboxType":     "single",
+		"EngineClause":    "",
+		"TemplateName":    "test",
 	}
 }
 
@@ -188,21 +201,27 @@ func TestInitSlavesTemplates_IncludeReplicaReadyWait(t *testing.T) {
 		"init_slaves_84": initSlaves84Template,
 	} {
 		data := common.StringMap{
-			"ShellPath":          "/bin/bash",
-			"Copyright":          "# test",
-			"AppVersion":         "test",
-			"DateTime":           "now",
-			"TemplateName":       name,
-			"SandboxDir":         "/tmp/rsandbox_1234",
-			"MasterLabel":        "master",
-			"MasterIp":           "127.0.0.1",
-			"RplUser":            "rsandbox",
-			"RplPassword":        "rsandbox",
-			"MasterAutoPosition": "",
-			"ChangeMasterExtra":  "",
-			"StartReplica":       "START REPLICA",
-			"NodeLabel":          "n",
-			"SlaveLabel":         "slave",
+			"ShellPath":           "/bin/bash",
+			"Copyright":           "# test",
+			"AppVersion":          "test",
+			"DateTime":            "now",
+			"TemplateName":        name,
+			"SandboxDir":          "/tmp/rsandbox_1234",
+			"MasterLabel":         "master",
+			"MasterIp":            "127.0.0.1",
+			"RplUser":             "rsandbox",
+			"RplPassword":         "rsandbox",
+			"MasterAutoPosition":  "",
+			"ChangeMasterExtra":   "",
+			"StartReplica":        "START REPLICA",
+			"NodeLabel":           "n",
+			"SlaveLabel":          "slave",
+			"ChangeMasterTo":      "CHANGE MASTER TO",
+			"MasterHostParam":     "MASTER_HOST",
+			"MasterPort":          "12345",
+			"MasterPortParam":     "MASTER_PORT",
+			"MasterUserParam":     "MASTER_USER",
+			"MasterPasswordParam": "MASTER_PASSWORD",
 			"Slaves": []common.StringMap{
 				{"NodeLabel": "n", "Node": 1, "SlaveLabel": "slave"},
 				{"NodeLabel": "n", "Node": 2, "SlaveLabel": "slave"},
@@ -214,11 +233,74 @@ func TestInitSlavesTemplates_IncludeReplicaReadyWait(t *testing.T) {
 			t.Errorf("%s template must define the wait_until_replica_ready helper (regression for #131)", name)
 		}
 		// The call must appear for each slave after the START REPLICA line.
-		if !strings.Contains(result, `wait_until_replica_ready "$SBDIR/n1/use" 60 1`) {
+		if !strings.Contains(result, `wait_until_replica_ready "$SBDIR/n1/use" 20 1`) {
 			t.Errorf("%s template must invoke wait for the first replica", name)
 		}
-		if !strings.Contains(result, `wait_until_replica_ready "$SBDIR/n2/use" 60 1`) {
+		if !strings.Contains(result, `wait_until_replica_ready "$SBDIR/n2/use" 20 1`) {
 			t.Errorf("%s template must invoke wait for the second replica", name)
 		}
+		// Verify the timeout warning message reflects the reduced max_attempts.
+		// This ensures the generated script won't wait longer than expected.
+		expectedWarning := "after $((max_attempts * sleep_sec))s"
+		if !strings.Contains(result, expectedWarning) {
+			t.Errorf("%s template must include a timeout warning message", name)
+		}
+	}
+}
+
+// TestWaitWsrepAfterStart_DoesNotBlockNonGalera verifies that the
+// wait_wsrep_after_start template (which runs for every sandbox node
+// after start, regardless of flavor) exits quickly on non-Galera MySQL.
+// On vanilla MySQL the wsrep status variable does not exist; the function
+// must detect this and return immediately. This is a pure template test.
+func TestWaitWsrepAfterStart_DoesNotBlockNonGalera(t *testing.T) {
+	data := baseTemplateData("mysql")
+	result := renderTemplate(t, waitWsrepAfterStartTemplate, data)
+
+	if !strings.Contains(result, "wait_until_wsrep_ready") {
+		t.Error("wait_wsrep_after_start template must call wait_until_wsrep_ready")
+	}
+	// The template appends '|| true' to make the wait best-effort.
+	if !strings.Contains(result, "|| true") {
+		t.Error("wait_wsrep_after_start must use '|| true' for best-effort semantics")
+	}
+}
+
+// TestSbInclude_WaitUntilWsrepReady_DetectsNonGalera verifies that the
+// wait_until_wsrep_ready function in sb_include.gotxt checks for the
+// existence of the wsrep_ready status variable before polling. Without
+// this guard, every non-Galera node would spin for the full timeout
+// (up to 120s per node), which caused the 5-minute total delay reported
+// on issue #131 after the v2.4.0 release.
+func TestSbInclude_WaitUntilWsrepReady_DetectsNonGalera(t *testing.T) {
+	data := baseTemplateData("mysql")
+	result := renderTemplate(t, sbIncludeTemplate, data)
+
+	// The early-return guard: grep for 'wsrep_ready' string in the output
+	// of SHOW STATUS. On non-Galera the output is empty and the function
+	// returns 0 immediately.
+	if !strings.Contains(result, `grep -q 'wsrep_ready'`) {
+		t.Error("wait_until_wsrep_ready must check if wsrep_ready variable exists (regression: #131 2-min delay on non-Galera)")
+	}
+	// The default max_attempts for wsrep should not exceed the budget.
+	if !strings.Contains(result, "local max_attempts=${2:-60}") {
+		t.Error("wait_until_wsrep_ready default max_attempts must remain 60 for Galera nodes, but the guard above must short-circuit on non-Galera")
+	}
+}
+
+// TestSbInclude_WaitUntilReplicaReady_BoundedWait verifies that the
+// wait_until_replica_ready function in sb_include.gotxt has a default
+// max_attempts that keeps the total wait within the allowed budget.
+// This prevents the 60s-per-replica delay that was part of the #131
+// v2.4.0 regression.
+func TestSbInclude_WaitUntilReplicaReady_BoundedWait(t *testing.T) {
+	data := baseTemplateData("mysql")
+	result := renderTemplate(t, sbIncludeTemplate, data)
+
+	// wait_until_replica_ready must have max_attempts=${2:-20}
+	// (wait_until_wsrep_ready keeps ${2:-60} for Galera nodes).
+	if !strings.Contains(result, `max_attempts=${2:-20}`) {
+		t.Errorf("wait_until_replica_ready max_attempts should be 20 to keep total wait ≤ %ds",
+			maxAllowedWaitSeconds)
 	}
 }

--- a/test/deploy-time-budget.sh
+++ b/test/deploy-time-budget.sh
@@ -45,31 +45,34 @@ MAX_DEPLOY_SECONDS="${MAX_DEPLOY_SECONDS:-45}"
 exit_code=0
 
 # Find a MySQL version >= 8.4 to test with (these are the versions
-# most affected by the #131 race condition).
+# most affected by the #131 race condition). Diagnostics go to stderr
+# so a failed discovery leaves stdout (captured into VERSION) empty.
 function find_test_version {
     if [ ! -d "$SANDBOX_BINARY" ]; then
-        echo "# SANDBOX_BINARY ($SANDBOX_BINARY) not found"
+        echo "# SANDBOX_BINARY ($SANDBOX_BINARY) not found" >&2
         return 1
     fi
+    local versions
     versions=$(ls "$SANDBOX_BINARY" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -t. -k1,1n -k2,2n -k3,3n)
     if [ -z "$versions" ]; then
-        echo "# No MySQL versions found in $SANDBOX_BINARY"
+        echo "# No MySQL versions found in $SANDBOX_BINARY" >&2
         return 1
     fi
-    # Prefer 8.4.x or 9.x (most affected by #131), fall back to any version
+    # Select the first 8.4+ or 9.x version (most affected by #131).
+    local v major minor
     for v in $versions; do
         major=$(echo "$v" | cut -d. -f1)
-        if [ "$major" -ge 8 ]; then
+        minor=$(echo "$v" | cut -d. -f2)
+        if [ "$major" -gt 8 ] || { [ "$major" -eq 8 ] && [ "$minor" -ge 4 ]; }; then
             echo "$v"
             return 0
         fi
     done
-    # Fallback to the last version found
-    echo "$versions" | tail -1
+    echo "# No MySQL version >= 8.4 found in $SANDBOX_BINARY" >&2
+    return 1
 }
 
 function cleanup {
-    local skip_confirm=""
     if command -v dbdeployer &>/dev/null; then
         dbdeployer delete all --skip-confirm 2>/dev/null || true
     fi
@@ -80,15 +83,17 @@ trap cleanup INT
 
 test_header "deploy-time-budget" "MAX_DEPLOY_SECONDS=$MAX_DEPLOY_SECONDS"
 
-VERSION=$(find_test_version)
-if [ -z "$VERSION" ]; then
-    echo "# No MySQL version available. Set SANDBOX_BINARY and unpack a tarball first."
-    echo "# SKIPPED: deploy-time-budget (no MySQL binaries)"
+if ! VERSION=$(find_test_version); then
+    echo "# No MySQL version >= 8.4 available. Set SANDBOX_BINARY and unpack a tarball first."
+    echo "# SKIPPED: deploy-time-budget (no suitable MySQL binaries)"
     exit 0
 fi
 
 echo "# Testing with MySQL $VERSION"
 echo "# Deploying replication (1 slave)..."
+
+# Start from a clean fixture so a stale rsandbox_* cannot make this pass.
+cleanup
 
 SECONDS=0
 dbdeployer deploy replication "$VERSION" -n 2 \

--- a/test/deploy-time-budget.sh
+++ b/test/deploy-time-budget.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# DBDeployer - The MySQL Sandbox
+# Copyright © 2006-2022 Giuseppe Maxia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# deploy-time-budget.sh
+# ---------------------
+# Verifies that "dbdeployer deploy replication" completes within a
+# reasonable time window and that replicas serve queries immediately
+# after deploy (no race condition as reported in issue #131).
+#
+# Requires:
+#   - dbdeployer binary in PATH or $PWD
+#   - SANDBOX_BINARY pointing to a directory with unpacked MySQL versions
+#   - go-unit-tests.sh must have passed (or use --skip-build)
+#
+# The test deploys replication with one slave, measures wall-clock time,
+# and asserts completion within MAX_DEPLOY_SECONDS (default 45).
+
+execdir=$(dirname "$0")
+cd "$execdir/.." || exit 1
+
+export DBDEPLOYER_BINARY="${DBDEPLOYER_BINARY:-$PWD/dbdeployer}"
+if [ ! -x "$DBDEPLOYER_BINARY" ]; then
+    echo "# Building dbdeployer..."
+    go build -o dbdeployer . || exit 1
+    DBDEPLOYER_BINARY="$PWD/dbdeployer"
+fi
+export PATH="$PWD:$PATH"
+
+source test/common.sh
+
+MAX_DEPLOY_SECONDS="${MAX_DEPLOY_SECONDS:-45}"
+exit_code=0
+
+# Find a MySQL version >= 8.4 to test with (these are the versions
+# most affected by the #131 race condition).
+function find_test_version {
+    if [ ! -d "$SANDBOX_BINARY" ]; then
+        echo "# SANDBOX_BINARY ($SANDBOX_BINARY) not found"
+        return 1
+    fi
+    versions=$(ls "$SANDBOX_BINARY" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -t. -k1,1n -k2,2n -k3,3n)
+    if [ -z "$versions" ]; then
+        echo "# No MySQL versions found in $SANDBOX_BINARY"
+        return 1
+    fi
+    # Prefer 8.4.x or 9.x (most affected by #131), fall back to any version
+    for v in $versions; do
+        major=$(echo "$v" | cut -d. -f1)
+        if [ "$major" -ge 8 ]; then
+            echo "$v"
+            return 0
+        fi
+    done
+    # Fallback to the last version found
+    echo "$versions" | tail -1
+}
+
+function cleanup {
+    local skip_confirm=""
+    if command -v dbdeployer &>/dev/null; then
+        dbdeployer delete all --skip-confirm 2>/dev/null || true
+    fi
+}
+
+trap cleanup EXIT
+trap cleanup INT
+
+test_header "deploy-time-budget" "MAX_DEPLOY_SECONDS=$MAX_DEPLOY_SECONDS"
+
+VERSION=$(find_test_version)
+if [ -z "$VERSION" ]; then
+    echo "# No MySQL version available. Set SANDBOX_BINARY and unpack a tarball first."
+    echo "# SKIPPED: deploy-time-budget (no MySQL binaries)"
+    exit 0
+fi
+
+echo "# Testing with MySQL $VERSION"
+echo "# Deploying replication (1 slave)..."
+
+SECONDS=0
+dbdeployer deploy replication "$VERSION" -n 1 \
+    --sandbox-binary="$SANDBOX_BINARY" 2>&1
+deploy_exit=$?
+elapsed=$SECONDS
+
+if [ "$deploy_exit" -ne 0 ]; then
+    echo "FAIL: dbdeployer deploy replication failed (exit=$deploy_exit)"
+    exit 1
+fi
+
+echo "# Deploy completed in ${elapsed}s"
+
+# Verify the replica responds immediately (no race, issue #131)
+SB_DIR=$(ls -d ~/sandboxes/rsandbox_* 2>/dev/null | head -1)
+if [ -z "$SB_DIR" ]; then
+    echo "FAIL: sandbox directory not found after deploy"
+    exit 1
+fi
+
+REPLICA_RESULT=$("$SB_DIR/s1" -BN -e "SELECT 'replica_ready';" 2>&1)
+if [ "$REPLICA_RESULT" != "replica_ready" ]; then
+    echo "FAIL: replica did not respond to immediate query: $REPLICA_RESULT"
+    echo "# This indicates the #131 race condition (deploy returned before replica was ready)"
+    exit_code=1
+else
+    echo "# Replica responded immediately: OK"
+fi
+
+# Verify the master is also reachable
+MASTER_RESULT=$("$SB_DIR/m" -BN -e "SELECT 'master_ready';" 2>&1)
+if [ "$MASTER_RESULT" != "master_ready" ]; then
+    echo "FAIL: master did not respond to query: $MASTER_RESULT"
+    exit_code=1
+else
+    echo "# Master responded: OK"
+fi
+
+# Time budget assertion
+if [ "$elapsed" -gt "$MAX_DEPLOY_SECONDS" ]; then
+    echo "FAIL: deploy took ${elapsed}s, which exceeds budget of ${MAX_DEPLOY_SECONDS}s"
+    echo "# This indicates a regression where wait times are too long"
+    exit_code=1
+else
+    echo "# Deploy time (${elapsed}s) within budget (${MAX_DEPLOY_SECONDS}s): OK"
+fi
+
+# Check for server errors
+check_for_log_errors "deploy-time-budget"
+
+if [ "$exit_code" -eq 0 ]; then
+    echo "# PASS: deploy-time-budget"
+else
+    echo "# FAIL: deploy-time-budget"
+fi
+exit $exit_code

--- a/test/deploy-time-budget.sh
+++ b/test/deploy-time-budget.sh
@@ -91,7 +91,7 @@ echo "# Testing with MySQL $VERSION"
 echo "# Deploying replication (1 slave)..."
 
 SECONDS=0
-dbdeployer deploy replication "$VERSION" -n 1 \
+dbdeployer deploy replication "$VERSION" -n 2 \
     --sandbox-binary="$SANDBOX_BINARY" 2>&1
 deploy_exit=$?
 elapsed=$SECONDS


### PR DESCRIPTION
After `dbdeployer deploy replication` in v2.4.0, the deployment takes ~5 minutes instead of seconds. This PR fixes two independent sources of excessive delay:

## Root causes

### 1. `wait_until_wsrep_ready` spins 120s per node on non-Galera MySQL

Commit `a2caf94` added `wait_wsrep_after_start` (to fix PXC/Galera flakes) but it runs unconditionally for every sandbox node. On vanilla MySQL, `SHOW STATUS LIKE 'wsrep_ready'` returns empty, `grep -qi 'ON'` fails, and the function waits the full 60 attempts × 2s = **120s per node**. With master + 1 slave that is **4 minutes** of unnecessary delay.

### 2. `wait_until_replica_ready` default max_attempts=60

The #131 fix (`4adea12`) polled replicas with `max_attempts=60, sleep_sec=1`. The original reporter found 5s was sufficient. Combined with the wsrep delay, this pushed the total to ~5min.

## Fixes

| File | Change |
|------|--------|
| `sb_include.gotxt` | `wait_until_wsrep_ready`: check if `wsrep_ready` status variable exists before polling; return immediately on non-Galera |
| `sb_include.gotxt` | `wait_until_replica_ready`: default `max_attempts` 60→20 |
| `init_slaves.gotxt` | Call with `20 1` instead of `60 1` |
| `init_slaves_84.gotxt` | Same |

## Tests added

- `TestWaitWsrepAfterStart_DoesNotBlockNonGalera` — verifies `wait_wsrep_after_start` template renders and uses `|| true`
- `TestSbInclude_WaitUntilWsrepReady_DetectsNonGalera` — verifies the wsrep-existence guard exists in `sb_include`
- `TestSbInclude_WaitUntilReplicaReady_BoundedWait` — verifies `max_attempts` default is 20 (≤30s budget)
- `TestInitSlavesTemplates_IncludeReplicaReadyWait` — enhanced to check timeout warning message; fixed pre-existing missing template fields

Fixes #131

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced replica readiness polling to a shorter, bounded retry window, speeding up initialization when replicas lag.
  * Improved readiness detection for non-Galera setups, avoiding unnecessary waits.
  * Adjusted wsrep readiness checks to complete gracefully on unsupported configurations.

* **Tests / CI**
  * Expanded coverage for replication startup and readiness behavior.
  * Added time-bounded deployment checks to detect readiness and startup regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->