### PR TITLE
The default prompt is mysql or MariaDB depending of the flavor

### DIFF
--- a/sandbox/sandbox.go
+++ b/sandbox/sandbox.go
@@ -423,7 +423,11 @@ func createSingleSandbox(sandboxDef SandboxDef) (execList []concurrent.Execution
 
 	versionFname := common.VersionToName(sandboxDef.Version)
 	if sandboxDef.Prompt == "" && !sandboxDef.FlavorInPrompt {
-		sandboxDef.Prompt = "mysql"
+		if sandboxDef.Flavor == common.MariaDbFlavor {
+			sandboxDef.Prompt = "MariaDB"
+		} else {
+			sandboxDef.Prompt = "mysql"
+		}
 	}
 	if sandboxDef.FlavorInPrompt {
 		sandboxDef.Prompt = sandboxDef.Flavor + "-" + sandboxDef.Prompt


### PR DESCRIPTION
For example, deploying a single instance with default settings

```
dbdeployer deploy single  13.1.
```

will give:

```
$ ./use
Welcome to the MariaDB monitor.  Commands end with ; or \g.
Your MariaDB connection id is 64
Server version: 13.1.0-MariaDB MariaDB Server

Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.

Help others discover MariaDB. Star it on GitHub: https://github.com/MariaDB/server

Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.

MariaDB [localhost:13100] {msandbox} ((none)) >
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * MariaDB sandboxes now default to the `MariaDB` prompt when no prompt is configured and flavor inclusion is disabled.
  * Other database flavors continue to use the `mysql` default prompt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->